### PR TITLE
feat: 结构化状态机翻译主线及后续问题修复 (#100)

### DIFF
--- a/src/anchor-normalization.ts
+++ b/src/anchor-normalization.ts
@@ -1,9 +1,22 @@
 import type { PromptSlice } from "./translation-state.js";
 
 export type PromptAnchor = PromptSlice["requiredAnchors"][number];
+type AnchorLike = Pick<PromptAnchor, "english" | "chineseHint">;
+type AnchorDisplayMode = "english-only" | "english-primary" | "chinese-primary";
+type AnchorDisplay = {
+  mode: AnchorDisplayMode;
+  english: string;
+  chineseDisplay: string;
+  canonical: string;
+  repeatText: string;
+};
 
 export function coalesceRequiredAnchors(requiredAnchors: readonly PromptAnchor[]): PromptAnchor[] {
   return requiredAnchors.filter((anchor) => !isShadowedByLongerAnchor(anchor, requiredAnchors));
+}
+
+export function formatAnchorDisplay(anchor: AnchorLike): string {
+  return resolveAnchorDisplay(anchor).canonical;
 }
 
 export function normalizeSegmentAnchorText(text: string, slice: PromptSlice | null): string {
@@ -141,22 +154,20 @@ function normalizeSingleAnchor(
   isRequired: boolean,
   isRepeatOrEstablished: boolean
 ): string {
-  const english = anchor.english.trim();
-  const chineseHint = anchor.chineseHint.trim();
+  const display = resolveAnchorDisplay(anchor);
+  const english = display.english;
+  const chineseHint = display.chineseDisplay;
 
   if (!english) {
     return text;
   }
 
   const escapedEnglish = escapeRegExp(english);
-  const hasDistinctChineseHint =
-    chineseHint.length > 0 && chineseHint.toLowerCase() !== english.toLowerCase();
-
   let normalized = text;
 
-  if (hasDistinctChineseHint) {
+  if (display.mode === "chinese-primary") {
     const escapedChinese = escapeRegExp(chineseHint);
-    const canonical = `${chineseHint}（${english}）`;
+    const canonical = display.canonical;
 
     normalized = normalized.replace(new RegExp(`${escapedEnglish}（${escapedChinese}）`, "g"), canonical);
     normalized = normalized.replace(new RegExp(`${escapedEnglish}（${escapedEnglish}）`, "g"), canonical);
@@ -165,6 +176,27 @@ function normalizeSingleAnchor(
 
     if (isRepeatOrEstablished) {
       normalized = normalized.replace(new RegExp(`${escapedChinese}（${escapedEnglish}）`, "g"), chineseHint);
+    }
+
+    return normalized;
+  }
+
+  if (display.mode === "english-primary") {
+    const escapedChinese = escapeRegExp(chineseHint);
+    const canonical = display.canonical;
+
+    normalized = normalized.replace(
+      new RegExp(`${escapedEnglish}\\s*${escapedChinese}（${escapedEnglish}）`, "g"),
+      canonical
+    );
+    normalized = normalized.replace(
+      new RegExp(`${escapedChinese}（${escapedEnglish}）`, "g"),
+      canonical
+    );
+    normalized = normalized.replace(new RegExp(`${escapedEnglish}（${escapedEnglish}）`, "g"), canonical);
+
+    if (isRepeatOrEstablished) {
+      normalized = normalized.replace(new RegExp(`${escapedEnglish}（${escapedChinese}）`, "g"), english);
     }
 
     return normalized;
@@ -286,4 +318,56 @@ function normalizeAnchorText(value: string): string {
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function resolveAnchorDisplay(anchor: AnchorLike): AnchorDisplay {
+  const english = anchor.english.trim();
+  const chineseHint = anchor.chineseHint.trim();
+
+  if (!english || !chineseHint || chineseHint.toLowerCase() === english.toLowerCase()) {
+    return {
+      mode: "english-only",
+      english,
+      chineseDisplay: "",
+      canonical: english,
+      repeatText: english
+    };
+  }
+
+  const strippedEnglishPrefix = stripLeadingEnglishHint(chineseHint, english);
+  const chineseDisplay = strippedEnglishPrefix ?? chineseHint;
+  if (shouldPreferEnglishPrimary(english, strippedEnglishPrefix)) {
+    return {
+      mode: "english-primary",
+      english,
+      chineseDisplay,
+      canonical: `${english}（${chineseDisplay}）`,
+      repeatText: english
+    };
+  }
+
+  return {
+    mode: "chinese-primary",
+    english,
+    chineseDisplay,
+    canonical: `${chineseDisplay}（${english}）`,
+    repeatText: chineseDisplay
+  };
+}
+
+function stripLeadingEnglishHint(chineseHint: string, english: string): string | null {
+  if (!chineseHint.toLowerCase().startsWith(english.toLowerCase())) {
+    return null;
+  }
+
+  const suffix = chineseHint.slice(english.length).trim();
+  return suffix.length > 0 ? suffix : null;
+}
+
+function shouldPreferEnglishPrimary(english: string, strippedEnglishPrefix: string | null): boolean {
+  if (strippedEnglishPrefix) {
+    return true;
+  }
+
+  return /^[A-Za-z0-9][A-Za-z0-9.+/_-]*$/.test(english);
 }

--- a/src/anchor-normalization.ts
+++ b/src/anchor-normalization.ts
@@ -210,6 +210,15 @@ export function normalizeExplicitRepairAnchorText(
         continue;
       }
 
+      if (matchingAnchor) {
+        const normalizedLine = injectAnchorIntoLine(translatedLine, matchingAnchor);
+        if (normalizedLine !== translatedLine) {
+          translatedLine = normalizedLine;
+          changed = true;
+          continue;
+        }
+      }
+
       translatedLine = translatedLine.replace(target.chineseHint, `${target.chineseHint}（${english}）`);
       changed = true;
     }
@@ -265,7 +274,8 @@ function resolvePromptAnchorForExplicitRepair(
   target: ExplicitRepairTarget,
   slice: PromptSlice
 ): PromptAnchor | null {
-  if (!target.english) {
+  const targetEnglish = target.english?.toLowerCase();
+  if (!targetEnglish) {
     return null;
   }
 
@@ -278,7 +288,7 @@ function resolvePromptAnchorForExplicitRepair(
   return (
     anchors.find(
       (anchor) =>
-        anchor.english === target.english &&
+        anchor.english.toLowerCase() === targetEnglish &&
         anchor.chineseHint !== target.english &&
         target.chineseHint.includes(anchor.chineseHint)
     ) ?? null
@@ -322,6 +332,10 @@ function normalizeSingleAnchor(
     const escapedChinese = escapeRegExp(chineseHint);
     const canonical = display.canonical;
 
+    normalized = normalized.replace(
+      new RegExp(`${escapedEnglish}（${escapedChinese}\\s+${escapedEnglish}）`, "g"),
+      canonical
+    );
     normalized = normalized.replace(
       new RegExp(`${escapedEnglish}\\s*${escapedChinese}（${escapedEnglish}）`, "g"),
       canonical
@@ -467,6 +481,7 @@ function parseExplicitRepairTarget(instruction: string): ExplicitRepairTarget | 
   const english =
     instruction.match(/关键术语“([^”]*[A-Za-z][^”]*)”/)?.[1]?.trim() ??
     instruction.match(/首现术语\s+([A-Za-z][A-Za-z0-9 .+/_-]*)\s+未补/)?.[1]?.trim() ??
+    instruction.match(/[：:]\s*([A-Za-z][A-Za-z0-9 .+/_-]*)\s+首次出现需补/)?.[1]?.trim() ??
     instruction.match(/括注“([^”]*[A-Za-z][^”]*)”/)?.[1]?.trim() ??
     instruction.match(/“([^”]*[A-Za-z][^”]*)”缺少/)?.[1]?.trim() ??
     null;
@@ -627,7 +642,8 @@ function resolveAnchorDisplay(anchor: AnchorLike): AnchorDisplay {
   }
 
   const strippedEnglishPrefix = stripLeadingEnglishHint(chineseHint, english);
-  const chineseDisplay = strippedEnglishPrefix ?? chineseHint;
+  const strippedEnglishSuffix = stripTrailingEnglishHint(strippedEnglishPrefix ?? chineseHint, english);
+  const chineseDisplay = strippedEnglishSuffix ?? strippedEnglishPrefix ?? chineseHint;
   if (shouldPreferEnglishPrimary(english, strippedEnglishPrefix)) {
     return {
       mode: "english-primary",
@@ -654,6 +670,20 @@ function stripLeadingEnglishHint(chineseHint: string, english: string): string |
 
   const suffix = chineseHint.slice(english.length).trim();
   return suffix.length > 0 ? suffix : null;
+}
+
+function stripTrailingEnglishHint(chineseHint: string, english: string): string | null {
+  if (!chineseHint.toLowerCase().endsWith(english.toLowerCase())) {
+    return null;
+  }
+
+  const prefix = chineseHint
+    .slice(0, Math.max(0, chineseHint.length - english.length))
+    .trim()
+    .replace(/[（(：:，,、\-–—\s]+$/u, "")
+    .trim();
+
+  return prefix.length > 0 ? prefix : null;
 }
 
 function shouldPreferEnglishPrimary(english: string, strippedEnglishPrefix: string | null): boolean {

--- a/src/anchor-normalization.ts
+++ b/src/anchor-normalization.ts
@@ -177,7 +177,9 @@ export function normalizeExplicitRepairAnchorText(
     for (const target of targets) {
       const sourceHeading = extractHeadingLikeLine(sourceLine);
       const translatedHeading = extractHeadingLikeLine(translatedLine);
+      const matchingAnchor = resolvePromptAnchorForExplicitRepair(target, slice);
       const english =
+        matchingAnchor?.english ??
         target.english ??
         resolveHeadingEnglishFromSource(target.chineseHint, sourceHeadingLines, translatedHeadingLines);
       if (!english) {
@@ -189,7 +191,10 @@ export function normalizeExplicitRepairAnchorText(
         translatedHeading &&
         stripInlineMarkdownMarkers(translatedHeading.content).includes(target.chineseHint)
       ) {
-        const normalizedHeading = normalizeHeadingRepairContent(translatedHeading.content, english);
+        const normalizedHeading =
+          matchingAnchor && translatedHeading.content.includes(matchingAnchor.chineseHint)
+            ? injectAnchorIntoLine(translatedHeading.content, matchingAnchor)
+            : normalizeHeadingRepairContent(translatedHeading.content, english);
         if (normalizedHeading !== translatedHeading.content) {
           translatedLine = translatedLine.replace(translatedHeading.content, normalizedHeading);
           changed = true;
@@ -254,6 +259,30 @@ function normalizeHeadingRepairContent(content: string, english: string): string
   }
 
   return content.replace(parentheticalMatch[0], `（${inner}，${english}）`);
+}
+
+function resolvePromptAnchorForExplicitRepair(
+  target: ExplicitRepairTarget,
+  slice: PromptSlice
+): PromptAnchor | null {
+  if (!target.english) {
+    return null;
+  }
+
+  const anchors = dedupePromptAnchors([
+    ...slice.requiredAnchors,
+    ...slice.repeatAnchors,
+    ...slice.establishedAnchors
+  ]);
+
+  return (
+    anchors.find(
+      (anchor) =>
+        anchor.english === target.english &&
+        anchor.chineseHint !== target.english &&
+        target.chineseHint.includes(anchor.chineseHint)
+    ) ?? null
+  );
 }
 
 function normalizeSingleAnchor(
@@ -437,6 +466,7 @@ function parseExplicitRepairTarget(instruction: string): ExplicitRepairTarget | 
 
   const english =
     instruction.match(/关键术语“([^”]*[A-Za-z][^”]*)”/)?.[1]?.trim() ??
+    instruction.match(/首现术语\s+([A-Za-z][A-Za-z0-9 .+/_-]*)\s+未补/)?.[1]?.trim() ??
     instruction.match(/括注“([^”]*[A-Za-z][^”]*)”/)?.[1]?.trim() ??
     instruction.match(/“([^”]*[A-Za-z][^”]*)”缺少/)?.[1]?.trim() ??
     null;

--- a/src/anchor-normalization.ts
+++ b/src/anchor-normalization.ts
@@ -347,14 +347,29 @@ type ExplicitRepairTarget = {
 
 function parseExplicitRepairTarget(instruction: string): ExplicitRepairTarget | null {
   const match = instruction.match(/需补为“([^（”]+)（([^）]+)）”/);
-  if (!match?.[1] || !match[2]) {
+  if (match?.[1] && match[2]) {
+    return {
+      chineseHint: match[1].trim(),
+      english: match[2].trim()
+    };
+  }
+
+  const english =
+    instruction.match(/关键术语“([^”]*[A-Za-z][^”]*)”/)?.[1]?.trim() ??
+    instruction.match(/“([^”]*[A-Za-z][^”]*)”缺少/)?.[1]?.trim() ??
+    null;
+  const locationText = instruction.match(/位置：[^“]*“([^”]+)”/)?.[1]?.trim() ?? null;
+  const chineseHint = locationText ? stripInlineMarkdownMarkers(locationText).trim() : null;
+
+  if (!english || !chineseHint) {
     return null;
   }
 
-  return {
-    chineseHint: match[1].trim(),
-    english: match[2].trim()
-  };
+  return { chineseHint, english };
+}
+
+function stripInlineMarkdownMarkers(text: string): string {
+  return text.replace(/[*_`~]/g, "");
 }
 
 function extractHeadingLikeLines(text: string): HeadingLine[] {

--- a/src/anchor-normalization.ts
+++ b/src/anchor-normalization.ts
@@ -48,6 +48,48 @@ export function normalizeSegmentAnchorText(text: string, slice: PromptSlice | nu
   return normalized;
 }
 
+export function injectPlannedAnchorText(
+  source: string,
+  text: string,
+  slice: PromptSlice | null
+): string {
+  if (!slice) {
+    return text;
+  }
+
+  const requiredAnchors = coalesceRequiredAnchors(dedupePromptAnchors(slice.requiredAnchors)).sort(
+    (left, right) => right.english.length - left.english.length
+  );
+  if (requiredAnchors.length === 0) {
+    return text;
+  }
+
+  const sourceLines = source.split(/\r?\n/);
+  const translatedLines = text.split(/\r?\n/);
+  let changed = false;
+
+  for (let index = 0; index < Math.min(sourceLines.length, translatedLines.length); index += 1) {
+    const sourceLine = sourceLines[index] ?? "";
+    let translatedLine = translatedLines[index] ?? "";
+
+    for (const anchor of requiredAnchors) {
+      if (!containsWholePhrase(sourceLine, anchor.english)) {
+        continue;
+      }
+
+      const injectedLine = injectAnchorIntoLine(translatedLine, anchor);
+      if (injectedLine !== translatedLine) {
+        translatedLine = injectedLine;
+        changed = true;
+      }
+    }
+
+    translatedLines[index] = translatedLine;
+  }
+
+  return changed ? translatedLines.join("\n") : text;
+}
+
 export function normalizeHeadingLikeAnchorText(
   source: string,
   text: string,
@@ -216,6 +258,48 @@ function collapseRepeatedEnglishParentheses(text: string, english: string): stri
   return text.replace(new RegExp(`（${escapedEnglish}）\\s*（${escapedEnglish}）`, "g"), `（${english}）`);
 }
 
+function injectAnchorIntoLine(text: string, anchor: PromptAnchor): string {
+  const display = resolveAnchorDisplay(anchor);
+
+  if (!display.english || display.mode === "english-only") {
+    return text;
+  }
+
+  if (display.mode === "english-primary") {
+    if (text.includes(display.canonical)) {
+      return text;
+    }
+
+    if (containsWholePhrase(text, display.english) && !text.includes(display.chineseDisplay)) {
+      return replaceWholePhraseOnce(text, display.english, display.canonical);
+    }
+
+    if (text.includes(anchor.chineseHint)) {
+      return replaceFirst(text, anchor.chineseHint, display.canonical);
+    }
+
+    if (display.chineseDisplay && text.includes(display.chineseDisplay)) {
+      return replaceFirst(text, display.chineseDisplay, display.canonical);
+    }
+
+    return text;
+  }
+
+  if (text.includes(display.canonical) || containsWholePhrase(text, display.english)) {
+    return text;
+  }
+
+  if (text.includes(display.chineseDisplay)) {
+    return replaceFirst(text, display.chineseDisplay, display.canonical);
+  }
+
+  if (text.includes(anchor.chineseHint)) {
+    return replaceFirst(text, anchor.chineseHint, display.canonical);
+  }
+
+  return text;
+}
+
 type HeadingLine = {
   raw: string;
   content: string;
@@ -318,6 +402,23 @@ function normalizeAnchorText(value: string): string {
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function replaceFirst(text: string, needle: string, replacement: string): string {
+  const index = text.indexOf(needle);
+  if (index === -1) {
+    return text;
+  }
+  return `${text.slice(0, index)}${replacement}${text.slice(index + needle.length)}`;
+}
+
+function replaceWholePhraseOnce(text: string, needle: string, replacement: string): string {
+  if (!/[A-Za-z]/.test(needle)) {
+    return replaceFirst(text, needle, replacement);
+  }
+
+  const pattern = new RegExp(`\\b${escapeRegExp(needle)}\\b`);
+  return text.replace(pattern, replacement);
 }
 
 function resolveAnchorDisplay(anchor: AnchorLike): AnchorDisplay {

--- a/src/anchor-normalization.ts
+++ b/src/anchor-normalization.ts
@@ -166,6 +166,8 @@ export function normalizeExplicitRepairAnchorText(
 
   const sourceLines = source.split(/\r?\n/);
   const translatedLines = text.split(/\r?\n/);
+  const sourceHeadingLines = extractHeadingLikeLines(source);
+  const translatedHeadingLines = extractHeadingLikeLines(text);
   let changed = false;
 
   for (let index = 0; index < Math.min(sourceLines.length, translatedLines.length); index += 1) {
@@ -173,18 +175,22 @@ export function normalizeExplicitRepairAnchorText(
     let translatedLine = translatedLines[index] ?? "";
 
     for (const target of targets) {
+      const english =
+        target.english ??
+        resolveHeadingEnglishFromSource(target.chineseHint, sourceHeadingLines, translatedHeadingLines);
+      if (!english) {
+        continue;
+      }
+
       if (
-        !containsWholePhrase(sourceLine, target.english) ||
+        !containsWholePhrase(sourceLine, english) ||
         !translatedLine.includes(target.chineseHint) ||
-        containsWholePhrase(translatedLine, target.english)
+        containsWholePhrase(translatedLine, english)
       ) {
         continue;
       }
 
-      translatedLine = translatedLine.replace(
-        target.chineseHint,
-        `${target.chineseHint}（${target.english}）`
-      );
+      translatedLine = translatedLine.replace(target.chineseHint, `${target.chineseHint}（${english}）`);
       changed = true;
     }
 
@@ -192,6 +198,29 @@ export function normalizeExplicitRepairAnchorText(
   }
 
   return changed ? translatedLines.join("\n") : text;
+}
+
+function resolveHeadingEnglishFromSource(
+  chineseHint: string,
+  sourceHeadingLines: readonly HeadingLine[],
+  translatedHeadingLines: readonly HeadingLine[]
+): string | null {
+  for (let index = 0; index < Math.min(sourceHeadingLines.length, translatedHeadingLines.length); index += 1) {
+    const sourceHeading = sourceHeadingLines[index];
+    const translatedHeading = translatedHeadingLines[index];
+    if (!sourceHeading || !translatedHeading) {
+      continue;
+    }
+
+    if (
+      stripInlineMarkdownMarkers(translatedHeading.content).trim() === chineseHint &&
+      /[A-Za-z]/.test(sourceHeading.content)
+    ) {
+      return sourceHeading.content.trim();
+    }
+  }
+
+  return null;
 }
 
 function normalizeSingleAnchor(
@@ -342,7 +371,7 @@ type HeadingLine = {
 
 type ExplicitRepairTarget = {
   chineseHint: string;
-  english: string;
+  english: string | null;
 };
 
 function parseExplicitRepairTarget(instruction: string): ExplicitRepairTarget | null {
@@ -358,10 +387,13 @@ function parseExplicitRepairTarget(instruction: string): ExplicitRepairTarget | 
     instruction.match(/关键术语“([^”]*[A-Za-z][^”]*)”/)?.[1]?.trim() ??
     instruction.match(/“([^”]*[A-Za-z][^”]*)”缺少/)?.[1]?.trim() ??
     null;
-  const locationText = instruction.match(/位置：[^“]*“([^”]+)”/)?.[1]?.trim() ?? null;
-  const chineseHint = locationText ? stripInlineMarkdownMarkers(locationText).trim() : null;
+  const locationText =
+    instruction.match(/位置：[^“]*“([^”]+)”/)?.[1]?.trim() ??
+    instruction.match(/`([^`]+)`/)?.[1]?.trim() ??
+    null;
+  const chineseHint = locationText ? stripHeadingMarkers(stripInlineMarkdownMarkers(locationText).trim()) : null;
 
-  if (!english || !chineseHint) {
+  if (!chineseHint) {
     return null;
   }
 
@@ -370,6 +402,10 @@ function parseExplicitRepairTarget(instruction: string): ExplicitRepairTarget | 
 
 function stripInlineMarkdownMarkers(text: string): string {
   return text.replace(/[*_`~]/g, "");
+}
+
+function stripHeadingMarkers(text: string): string {
+  return text.replace(/^#{1,6}\s+/, "").trim();
 }
 
 function extractHeadingLikeLines(text: string): HeadingLine[] {

--- a/src/anchor-normalization.ts
+++ b/src/anchor-normalization.ts
@@ -175,11 +175,26 @@ export function normalizeExplicitRepairAnchorText(
     let translatedLine = translatedLines[index] ?? "";
 
     for (const target of targets) {
+      const sourceHeading = extractHeadingLikeLine(sourceLine);
+      const translatedHeading = extractHeadingLikeLine(translatedLine);
       const english =
         target.english ??
         resolveHeadingEnglishFromSource(target.chineseHint, sourceHeadingLines, translatedHeadingLines);
       if (!english) {
         continue;
+      }
+
+      if (
+        sourceHeading &&
+        translatedHeading &&
+        stripInlineMarkdownMarkers(translatedHeading.content).includes(target.chineseHint)
+      ) {
+        const normalizedHeading = normalizeHeadingRepairContent(translatedHeading.content, english);
+        if (normalizedHeading !== translatedHeading.content) {
+          translatedLine = translatedLine.replace(translatedHeading.content, normalizedHeading);
+          changed = true;
+          continue;
+        }
       }
 
       if (
@@ -221,6 +236,24 @@ function resolveHeadingEnglishFromSource(
   }
 
   return null;
+}
+
+function normalizeHeadingRepairContent(content: string, english: string): string {
+  if (!english || containsWholePhrase(content, english)) {
+    return content;
+  }
+
+  const parentheticalMatch = content.match(/（([^）]*[A-Za-z][^）]*)）(?!.*（)/);
+  if (!parentheticalMatch?.[1]) {
+    return `${content}（${english}）`;
+  }
+
+  const inner = parentheticalMatch[1].trim();
+  if (containsWholePhrase(inner, english)) {
+    return content;
+  }
+
+  return content.replace(parentheticalMatch[0], `（${inner}，${english}）`);
 }
 
 function normalizeSingleAnchor(
@@ -369,6 +402,25 @@ type HeadingLine = {
   content: string;
 };
 
+function extractHeadingLikeLine(rawLine: string): HeadingLine | null {
+  const trimmed = rawLine.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const atxMatch = trimmed.match(/^#{1,6}[ \t]+(.+?)(?:[ \t]+#+)?$/);
+  if (atxMatch?.[1]) {
+    return { raw: rawLine, content: atxMatch[1].trim() };
+  }
+
+  const boldMatch = trimmed.match(/^\*\*(.+)\*\*$/);
+  if (boldMatch?.[1]) {
+    return { raw: rawLine, content: boldMatch[1].trim() };
+  }
+
+  return null;
+}
+
 type ExplicitRepairTarget = {
   chineseHint: string;
   english: string | null;
@@ -385,10 +437,12 @@ function parseExplicitRepairTarget(instruction: string): ExplicitRepairTarget | 
 
   const english =
     instruction.match(/关键术语“([^”]*[A-Za-z][^”]*)”/)?.[1]?.trim() ??
+    instruction.match(/括注“([^”]*[A-Za-z][^”]*)”/)?.[1]?.trim() ??
     instruction.match(/“([^”]*[A-Za-z][^”]*)”缺少/)?.[1]?.trim() ??
     null;
   const locationText =
-    instruction.match(/位置：[^“]*“([^”]+)”/)?.[1]?.trim() ??
+    instruction.match(/位置：[^。；\n“]*“([^”]+)”/)?.[1]?.trim() ??
+    instruction.match(/位置：(.+?)。问题[:：]/)?.[1]?.trim() ??
     instruction.match(/`([^`]+)`/)?.[1]?.trim() ??
     null;
   const chineseHint = locationText ? stripHeadingMarkers(stripInlineMarkdownMarkers(locationText).trim()) : null;
@@ -412,20 +466,9 @@ function extractHeadingLikeLines(text: string): HeadingLine[] {
   const headings: HeadingLine[] = [];
 
   for (const rawLine of text.split(/\r?\n/)) {
-    const trimmed = rawLine.trim();
-    if (!trimmed) {
-      continue;
-    }
-
-    const atxMatch = trimmed.match(/^#{1,6}[ \t]+(.+?)(?:[ \t]+#+)?$/);
-    if (atxMatch?.[1]) {
-      headings.push({ raw: rawLine, content: atxMatch[1].trim() });
-      continue;
-    }
-
-    const boldMatch = trimmed.match(/^\*\*(.+)\*\*$/);
-    if (boldMatch?.[1]) {
-      headings.push({ raw: rawLine, content: boldMatch[1].trim() });
+    const heading = extractHeadingLikeLine(rawLine);
+    if (heading) {
+      headings.push(heading);
     }
   }
 

--- a/src/anchor-normalization.ts
+++ b/src/anchor-normalization.ts
@@ -48,6 +48,61 @@ export function normalizeSegmentAnchorText(text: string, slice: PromptSlice | nu
   return normalizeRepeatedEnglishParenthesesWithLocalHints(normalized);
 }
 
+export function normalizeSourceSurfaceAnchorText(
+  source: string,
+  text: string,
+  slice: PromptSlice | null
+): string {
+  if (!slice) {
+    return text;
+  }
+
+  const anchors = dedupePromptAnchors([
+    ...slice.requiredAnchors,
+    ...slice.repeatAnchors,
+    ...slice.establishedAnchors
+  ]);
+  if (anchors.length === 0) {
+    return text;
+  }
+
+  const sourceLines = source.split(/\r?\n/);
+  const translatedLines = text.split(/\r?\n/);
+  let changed = false;
+
+  for (let index = 0; index < Math.min(sourceLines.length, translatedLines.length); index += 1) {
+    const sourceLine = sourceLines[index] ?? "";
+    let translatedLine = translatedLines[index] ?? "";
+    const sourceAnchors = coalesceSourceLineAnchors(
+      anchors.filter((anchor) => containsWholePhrase(sourceLine, anchor.english))
+    );
+    if (sourceAnchors.length === 0) {
+      continue;
+    }
+
+    for (const sourceAnchor of sourceAnchors) {
+      const siblingVariants = anchors.filter(
+        (candidate) =>
+          candidate.familyId === sourceAnchor.familyId &&
+          candidate.anchorId !== sourceAnchor.anchorId &&
+          !containsWholePhrase(sourceLine, candidate.english)
+      );
+
+      for (const variant of siblingVariants) {
+        const normalizedLine = collapseUnexpectedFamilyVariant(translatedLine, variant, sourceAnchor);
+        if (normalizedLine !== translatedLine) {
+          translatedLine = normalizedLine;
+          changed = true;
+        }
+      }
+    }
+
+    translatedLines[index] = translatedLine;
+  }
+
+  return changed ? translatedLines.join("\n") : text;
+}
+
 export function injectPlannedAnchorText(
   source: string,
   text: string,
@@ -71,12 +126,11 @@ export function injectPlannedAnchorText(
   for (let index = 0; index < Math.min(sourceLines.length, translatedLines.length); index += 1) {
     const sourceLine = sourceLines[index] ?? "";
     let translatedLine = translatedLines[index] ?? "";
+    const lineAnchors = coalesceSourceLineAnchors(
+      requiredAnchors.filter((anchor) => containsWholePhrase(sourceLine, anchor.english))
+    );
 
-    for (const anchor of requiredAnchors) {
-      if (!containsWholePhrase(sourceLine, anchor.english)) {
-        continue;
-      }
-
+    for (const anchor of lineAnchors) {
       if (shouldSkipAnchorInjectionForCommandPhrase(sourceLine, anchor)) {
         continue;
       }
@@ -121,11 +175,13 @@ export function normalizeHeadingLikeAnchorText(
   for (let index = 0; index < Math.min(sourceHeadingLines.length, translatedHeadingLines.length); index += 1) {
     const sourceLine = sourceHeadingLines[index]!;
     const translatedLine = translatedHeadingLines[index]!;
+    const lineAnchors = coalesceSourceLineAnchors(
+      requiredAnchors.filter((anchor) => containsWholePhrase(sourceLine.content, anchor.english))
+    );
 
     let normalizedLine = translatedLine.raw;
-    for (const anchor of requiredAnchors) {
+    for (const anchor of lineAnchors) {
       if (
-        !containsWholePhrase(sourceLine.content, anchor.english) ||
         !anchor.chineseHint ||
         anchor.chineseHint.toLowerCase() === anchor.english.toLowerCase() ||
         !normalizedLine.includes(anchor.chineseHint) ||
@@ -407,6 +463,59 @@ function injectAnchorIntoLine(text: string, anchor: PromptAnchor): string {
   }
 
   return text;
+}
+
+function collapseUnexpectedFamilyVariant(
+  text: string,
+  variant: PromptAnchor,
+  sourceAnchor: PromptAnchor
+): string {
+  const variantDisplay = resolveAnchorDisplay(variant);
+  const sourceDisplay = resolveAnchorDisplay(sourceAnchor);
+  let normalized = text;
+  const variantSuffix = variant.english.startsWith(`${sourceAnchor.english} `)
+    ? variant.english.slice(sourceAnchor.english.length).trim()
+    : "";
+
+  const replacements: Array<[string, string]> = [
+    [variantDisplay.canonical, sourceDisplay.canonical],
+    [`${variant.english}（${sourceAnchor.english}）`, sourceDisplay.canonical],
+    [`${variant.english}（${sourceDisplay.chineseDisplay}）`, sourceDisplay.canonical],
+    [`${variantDisplay.canonical}（${sourceAnchor.english}）`, sourceDisplay.canonical],
+    [`${sourceDisplay.canonical}（${sourceAnchor.english}）`, sourceDisplay.canonical]
+  ];
+
+  if (variantSuffix) {
+    replacements.push(
+      [`${sourceDisplay.canonical} ${variantSuffix}（${sourceAnchor.english}）`, sourceDisplay.canonical],
+      [`${sourceDisplay.canonical} ${variantSuffix}`, sourceDisplay.canonical]
+    );
+  }
+
+  for (const [from, to] of replacements) {
+    if (from && to && normalized.includes(from)) {
+      normalized = normalized.split(from).join(to);
+    }
+  }
+
+  if (containsWholePhrase(normalized, variant.english) && !containsWholePhrase(text, sourceAnchor.english)) {
+    normalized = replaceWholePhraseOnce(normalized, variant.english, sourceDisplay.canonical);
+  }
+
+  return normalized;
+}
+
+function coalesceSourceLineAnchors(anchors: readonly PromptAnchor[]): PromptAnchor[] {
+  return anchors.filter(
+    (anchor) =>
+      !anchors.some(
+        (candidate) =>
+          candidate.anchorId !== anchor.anchorId &&
+          candidate.familyId === anchor.familyId &&
+          candidate.english.length > anchor.english.length &&
+          containsWholePhrase(candidate.english, anchor.english)
+      )
+  );
 }
 
 function shouldSkipAnchorInjectionForCommandPhrase(sourceLine: string, anchor: PromptAnchor): boolean {

--- a/src/anchor-normalization.ts
+++ b/src/anchor-normalization.ts
@@ -77,6 +77,10 @@ export function injectPlannedAnchorText(
         continue;
       }
 
+      if (shouldSkipAnchorInjectionForCommandPhrase(sourceLine, anchor)) {
+        continue;
+      }
+
       const injectedLine = injectAnchorIntoLine(translatedLine, anchor);
       if (injectedLine !== translatedLine) {
         translatedLine = injectedLine;
@@ -298,6 +302,37 @@ function injectAnchorIntoLine(text: string, anchor: PromptAnchor): string {
   }
 
   return text;
+}
+
+function shouldSkipAnchorInjectionForCommandPhrase(sourceLine: string, anchor: PromptAnchor): boolean {
+  const trimmed = sourceLine.trim();
+  const bulletMatch = trimmed.match(/^(?:[-*+]|\d+[.)])\s+(.+)$/);
+  const body = bulletMatch?.[1]?.trim();
+  if (!body) {
+    return false;
+  }
+
+  const english = anchor.english.trim();
+  if (!english || /\s/.test(english)) {
+    return false;
+  }
+
+  const withoutTrailingExplanation = body.replace(/\s*\([^)]*\)\s*$/, "").trim();
+  const leadingToken = withoutTrailingExplanation.match(/^([A-Za-z][A-Za-z0-9+._/-]*)\b/)?.[1]?.trim();
+  if (!leadingToken || leadingToken.toLowerCase() !== english.toLowerCase()) {
+    return false;
+  }
+
+  const remainder = withoutTrailingExplanation.slice(leadingToken.length).trim();
+  if (!remainder) {
+    return false;
+  }
+
+  if (remainder.includes(",")) {
+    return true;
+  }
+
+  return /^[A-Za-z0-9./_-]/.test(remainder);
 }
 
 type HeadingLine = {

--- a/src/anchor-normalization.ts
+++ b/src/anchor-normalization.ts
@@ -45,7 +45,7 @@ export function normalizeSegmentAnchorText(text: string, slice: PromptSlice | nu
     );
   }
 
-  return normalized;
+  return normalizeRepeatedEnglishParenthesesWithLocalHints(normalized);
 }
 
 export function injectPlannedAnchorText(
@@ -454,6 +454,38 @@ function replaceWholePhraseOnce(text: string, needle: string, replacement: strin
 
   const pattern = new RegExp(`\\b${escapeRegExp(needle)}\\b`);
   return text.replace(pattern, replacement);
+}
+
+function normalizeRepeatedEnglishParenthesesWithLocalHints(text: string): string {
+  const localEnglishPrimary = new Map<string, string>();
+  const englishPrimaryPattern = /\b([A-Za-z][A-Za-z0-9.+/_ -]{1,})（([^（）\n]+)）/g;
+
+  for (const match of text.matchAll(englishPrimaryPattern)) {
+    const english = match[1]?.trim();
+    const explainer = match[2]?.trim();
+    if (!english || !explainer) {
+      continue;
+    }
+    if (english.toLowerCase() === explainer.toLowerCase()) {
+      continue;
+    }
+    localEnglishPrimary.set(english.toLowerCase(), `${english}（${explainer}）`);
+  }
+
+  return text.replace(englishPrimaryPattern, (raw, englishRaw, innerRaw) => {
+    const english = String(englishRaw).trim();
+    const inner = String(innerRaw).trim();
+    if (!english || !inner) {
+      return raw;
+    }
+
+    if (english.toLowerCase() !== inner.toLowerCase()) {
+      return raw;
+    }
+
+    const canonical = localEnglishPrimary.get(english.toLowerCase());
+    return canonical ?? english;
+  });
 }
 
 function resolveAnchorDisplay(anchor: AnchorLike): AnchorDisplay {

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -11,6 +11,7 @@ import {
 } from "./internal/prompts/scheme-h.js";
 import { DefaultCodexExecutor, type CodexExecutor } from "./codex-exec.js";
 import {
+  formatAnchorDisplay,
   normalizeExplicitRepairAnchorText,
   normalizeHeadingLikeAnchorText,
   normalizeSegmentAnchorText
@@ -657,7 +658,7 @@ type DraftedSegmentState = {
 };
 
 function summarizePromptAnchor(anchor: PromptSlice["requiredAnchors"][number]): string {
-  return `${anchor.chineseHint || "未定中文"} / ${anchor.english}`;
+  return formatAnchorDisplay(anchor) || "未定中文";
 }
 
 function buildSegmentPromptContext(

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -773,19 +773,49 @@ function inferRepairLocationLabelFromInstruction(
   if (instruction.includes("引导句") || instruction.includes("说明句") || instruction.includes("导语句")) {
     return "列表引导句";
   }
-  if (instruction.includes("当前句") || instruction.includes("该句") || /位置：[^。\n]*“[^”]+”/.test(instruction)) {
+  if (hasSentenceLocalRepairTarget(instruction)) {
     return "正文句";
   }
 
   return inferRepairLocationLabel(segmentSource);
 }
 
+function hasSentenceLocalRepairTarget(instruction: string): boolean {
+  return (
+    instruction.includes("当前句") ||
+    instruction.includes("该句") ||
+    instruction.includes("句内") ||
+    instruction.includes("句中") ||
+    instruction.includes("首句") ||
+    instruction.includes("末句") ||
+    /第\d+段(?:第\d+句|首句|末句)/.test(instruction) ||
+    /位置：[^。\n]*“[^”]+”/.test(instruction)
+  );
+}
+
 function inferRepairAnchorId(
   slice: PromptSlice,
+  segmentSource: string,
   instruction: string
 ): string | null {
   const haystack = instruction.toLowerCase();
-  const anchors = [...slice.requiredAnchors, ...slice.repeatAnchors, ...slice.establishedAnchors];
+  const anchors = [...slice.requiredAnchors, ...slice.repeatAnchors, ...slice.establishedAnchors].filter(
+    (anchor) => segmentSource.toLowerCase().includes(anchor.english.trim().toLowerCase())
+  );
+
+  const explicitTargets = extractExplicitEnglishTargetsFromMustFix([instruction]);
+  for (const target of explicitTargets) {
+    const normalizedTarget = target.toLowerCase();
+    const matchedAnchor = anchors.find(
+      (anchor) =>
+        normalizedTarget.includes(anchor.english.toLowerCase()) ||
+        anchor.english.toLowerCase().includes(normalizedTarget)
+    );
+    if (matchedAnchor) {
+      return matchedAnchor.anchorId;
+    }
+  }
+
   for (const anchor of anchors) {
     if (
       haystack.includes(anchor.english.toLowerCase()) ||
@@ -799,9 +829,10 @@ function inferRepairAnchorId(
 
 function inferRepairTargetEnglish(
   slice: PromptSlice,
+  segmentSource: string,
   instruction: string
 ): string | null {
-  const anchorId = inferRepairAnchorId(slice, instruction);
+  const anchorId = inferRepairAnchorId(slice, segmentSource, instruction);
   if (anchorId) {
     const anchors = [...slice.requiredAnchors, ...slice.repeatAnchors, ...slice.establishedAnchors];
     const matchedAnchor = anchors.find((anchor) => anchor.anchorId === anchorId);
@@ -839,7 +870,7 @@ function buildStructuredSegmentAuditResult(
   const repairTasks: RepairTask[] = filteredAudit.must_fix.map((instruction, index) => ({
     id: `${draftedSegment.segmentId}-repair-${state.repairs.length + index + 1}`,
     segmentId: draftedSegment.segmentId,
-    anchorId: inferRepairAnchorId(slice, instruction),
+    anchorId: inferRepairAnchorId(slice, draftedSegment.segment.source, instruction),
     failureType: inferRepairFailureType(filteredAudit, instruction),
     locationLabel: inferRepairLocationLabelFromInstruction(draftedSegment.segment.source, instruction),
     instruction,
@@ -865,7 +896,7 @@ function suppressCoveredAnchorMustFix(
   }
 
   const remainingMustFix = audit.must_fix.filter((instruction) => {
-    const targetEnglish = inferRepairTargetEnglish(slice, instruction);
+    const targetEnglish = inferRepairTargetEnglish(slice, draftedSegment.segment.source, instruction);
     if (!targetEnglish) {
       return true;
     }
@@ -1559,9 +1590,7 @@ function buildRepairPromptContext(
   const explicitEnglishTargets = extractExplicitEnglishTargetsFromMustFix(mustFix);
   const conceptFamilyTargets = extractConceptFamilyTargets(explicitEnglishTargets);
   const duplicatePendingAnchorGroups = collectDuplicatePendingAnchorGroups(promptContext);
-  const hasQuotedSentenceLocation =
-    mustFix.some((item) => /位置：[^。\n]*“[^”]+”/.test(item)) &&
-    mustFix.some((item) => item.includes("首次出现") || item.includes("中英文") || item.includes("中英对照"));
+  const hasQuotedSentenceLocation = mustFix.some((item) => hasSentenceLocalRepairTarget(item));
   const targetsHeadingLikeAnchor = mustFix.some(
     (item) => item.includes("标题") || item.includes("首次出现") || item.includes("中英对照")
   );

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -756,6 +756,29 @@ function inferRepairLocationLabel(segmentSource: string): string {
   return "正文段落";
 }
 
+function inferRepairLocationLabelFromInstruction(
+  segmentSource: string,
+  instruction: string
+): string {
+  if (instruction.includes("标题")) {
+    return "标题";
+  }
+  if (instruction.includes("列表项") || instruction.includes("项目符号")) {
+    return "列表项";
+  }
+  if (instruction.includes("引用段") || instruction.includes("引用中的") || instruction.includes("引用句")) {
+    return "引用段";
+  }
+  if (instruction.includes("引导句") || instruction.includes("说明句") || instruction.includes("导语句")) {
+    return "列表引导句";
+  }
+  if (instruction.includes("当前句") || instruction.includes("该句") || /位置：[^。\n]*“[^”]+”/.test(instruction)) {
+    return "正文句";
+  }
+
+  return inferRepairLocationLabel(segmentSource);
+}
+
 function inferRepairAnchorId(
   slice: PromptSlice,
   instruction: string
@@ -811,14 +834,13 @@ function buildStructuredSegmentAuditResult(
 ): StateSegmentAuditResult {
   const chunkId = draftedSegment.segmentId.split("-segment-")[0] ?? `chunk-${draftedSegment.segment.index + 1}`;
   const slice = buildSegmentTaskSlice(state, chunkId, draftedSegment.segmentId);
-  const locationLabel = inferRepairLocationLabel(draftedSegment.segment.source);
   const filteredAudit = suppressCoveredAnchorMustFix(state, draftedSegment, slice, audit);
   const repairTasks: RepairTask[] = filteredAudit.must_fix.map((instruction, index) => ({
     id: `${draftedSegment.segmentId}-repair-${state.repairs.length + index + 1}`,
     segmentId: draftedSegment.segmentId,
     anchorId: inferRepairAnchorId(slice, instruction),
     failureType: inferRepairFailureType(filteredAudit, instruction),
-    locationLabel,
+    locationLabel: inferRepairLocationLabelFromInstruction(draftedSegment.segment.source, instruction),
     instruction,
     status: "pending"
   }));
@@ -1392,7 +1414,11 @@ function splitRepairTaskBatches(
         ? state.anchors.find((anchor) => anchor.id === nextTask.anchorId)?.familyId ?? nextTask.anchorId
         : null;
       const relatedToBatch = nextFamily ? batchFamilies.has(nextFamily) : false;
-      if (batch.length >= normalizedBatchSize && !relatedToBatch) {
+      const spansMultipleLocations =
+        batch.some(
+          (task) => task.segmentId === nextTask.segmentId && task.locationLabel !== nextTask.locationLabel
+        );
+      if (batch.length >= normalizedBatchSize && !relatedToBatch && !spansMultipleLocations) {
         break;
       }
 

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -1255,16 +1255,37 @@ function collectPlainCommandTokens(
       continue;
     }
 
-    const bulletMatch = trimmed.match(/^(?:[-*+]|\d+[.)])\s+([A-Za-z][A-Za-z0-9+._/-]*)\b/);
-    const token = bulletMatch?.[1]?.trim();
-    if (!token || sourceInlineCodeTokens.has(token)) {
+    const bulletMatch = trimmed.match(/^(?:[-*+]|\d+[.)])\s+(.+)$/);
+    const body = bulletMatch?.[1]?.trim();
+    if (!body) {
       continue;
     }
 
-    tokens.add(token);
+    const commandPhrases = extractPlainCommandPhrases(body);
+    const leadingToken = body.match(/^([A-Za-z][A-Za-z0-9+._/-]*)\b/)?.[1]?.trim();
+    if (leadingToken && !sourceInlineCodeTokens.has(leadingToken)) {
+      tokens.add(leadingToken);
+    }
+    for (const phrase of commandPhrases) {
+      if (!sourceInlineCodeTokens.has(phrase)) {
+        tokens.add(phrase);
+      }
+    }
   }
 
   return tokens;
+}
+
+function extractPlainCommandPhrases(body: string): string[] {
+  const withoutTrailingExplanation = body.replace(/\s*\([^)]*\)\s*$/, "").trim();
+  if (!withoutTrailingExplanation) {
+    return [];
+  }
+
+  return withoutTrailingExplanation
+    .split(/\s*,\s*/)
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0 && /[A-Za-z]/.test(item));
 }
 
 type ProtectedChunkSegment = {

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -12,6 +12,7 @@ import {
 import { DefaultCodexExecutor, type CodexExecutor } from "./codex-exec.js";
 import {
   formatAnchorDisplay,
+  injectPlannedAnchorText,
   normalizeExplicitRepairAnchorText,
   normalizeHeadingLikeAnchorText,
   normalizeSegmentAnchorText
@@ -1331,9 +1332,14 @@ async function translateProtectedSegment(
     stripAddedInlineCodeFromPlainPaths(protectedSource, draftResult.text),
     chunkPromptContext.stateSlice
   );
-  const normalizedHeadingDraftText = normalizeHeadingLikeAnchorText(
+  const injectedDraftText = injectPlannedAnchorText(
     protectedSource,
     normalizedDraftText,
+    chunkPromptContext.stateSlice
+  );
+  const normalizedHeadingDraftText = normalizeHeadingLikeAnchorText(
+    protectedSource,
+    injectedDraftText,
     chunkPromptContext.stateSlice
   );
   const canonicalProtectedBody = reprotectMarkdownSpans(normalizedHeadingDraftText, combinedSpans);
@@ -1422,9 +1428,14 @@ async function repairDraftedSegment(
       stripAddedInlineCodeFromPlainPaths(draftedSegment.protectedSource, repairResult.text),
       buildSegmentTaskSlice(context.state, context.chunkId, draftedSegment.segmentId)
     );
-    const normalizedHeadingRepairText = normalizeHeadingLikeAnchorText(
+    const injectedRepairText = injectPlannedAnchorText(
       draftedSegment.protectedSource,
       normalizedRepairText,
+      buildSegmentTaskSlice(context.state, context.chunkId, draftedSegment.segmentId)
+    );
+    const normalizedHeadingRepairText = normalizeHeadingLikeAnchorText(
+      draftedSegment.protectedSource,
+      injectedRepairText,
       buildSegmentTaskSlice(context.state, context.chunkId, draftedSegment.segmentId)
     );
     const normalizedExplicitRepairText = normalizeExplicitRepairAnchorText(

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -1132,7 +1132,11 @@ async function translateProtectedChunk(
         hardPassProtectedSource,
         styleResult.text
       );
-      restoredChunkBody = restoreMarkdownSpans(normalizedStyleText, chunkSpans);
+      const restoredInlineStyleText = restoreInlineCodeFromSourceShape(
+        hardPassProtectedSource,
+        normalizedStyleText
+      );
+      restoredChunkBody = restoreMarkdownSpans(restoredInlineStyleText, chunkSpans);
       if (looksLikeMetaTaskResponse(restoredChunkBody)) {
         report(
           context.options,
@@ -1231,6 +1235,122 @@ function stripAddedInlineCodeFromPlainPaths(source: string, translated: string):
   }
 
   return normalized;
+}
+
+function restoreInlineCodeFromSourceShape(source: string, translated: string): string {
+  const sourceLines = source.split(/\r?\n/);
+  const translatedLines = translated.split(/\r?\n/);
+  let changed = false;
+
+  for (let index = 0; index < Math.min(sourceLines.length, translatedLines.length); index += 1) {
+    const sourceLine = sourceLines[index] ?? "";
+    let translatedLine = translatedLines[index] ?? "";
+    const sourceInlineCodeCounts = collectInlineCodeCounts(sourceLine);
+    if (sourceInlineCodeCounts.size === 0) {
+      continue;
+    }
+
+    const translatedInlineCodeCounts = collectInlineCodeCounts(translatedLine);
+    for (const [token, sourceCount] of sourceInlineCodeCounts.entries()) {
+      let missingCount = sourceCount - (translatedInlineCodeCounts.get(token) ?? 0);
+      while (missingCount > 0) {
+        const restoredLine = wrapPlainOccurrenceOutsideInlineCode(translatedLine, token);
+        if (restoredLine === translatedLine) {
+          break;
+        }
+        translatedLine = restoredLine;
+        missingCount -= 1;
+        changed = true;
+      }
+    }
+
+    translatedLines[index] = translatedLine;
+  }
+
+  return changed ? translatedLines.join("\n") : translated;
+}
+
+function collectInlineCodeCounts(text: string): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const match of text.matchAll(/`([^`\n]+)`/g)) {
+    const token = match[1]?.trim();
+    if (!token) {
+      continue;
+    }
+    counts.set(token, (counts.get(token) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function wrapPlainOccurrenceOutsideInlineCode(text: string, token: string): string {
+  if (!token) {
+    return text;
+  }
+
+  let output = "";
+  let index = 0;
+  let textStart = 0;
+
+  while (index < text.length) {
+    if (text[index] !== "`") {
+      index += 1;
+      continue;
+    }
+
+    const plainSegment = text.slice(textStart, index);
+    const replaced = replacePlainTokenInSegment(plainSegment, token);
+    output += replaced.segment;
+    if (replaced.replaced) {
+      output += text.slice(index);
+      return output;
+    }
+
+    let tickCount = 1;
+    while (text[index + tickCount] === "`") {
+      tickCount += 1;
+    }
+
+    const fence = "`".repeat(tickCount);
+    const inlineStart = index;
+    index += tickCount;
+
+    let closingIndex = -1;
+    while (index < text.length) {
+      if (text.slice(index, index + tickCount) === fence) {
+        closingIndex = index;
+        break;
+      }
+      index += 1;
+    }
+
+    if (closingIndex < 0) {
+      output += text.slice(inlineStart, inlineStart + tickCount);
+      textStart = inlineStart + tickCount;
+      index = textStart;
+      continue;
+    }
+
+    output += text.slice(inlineStart, closingIndex + tickCount);
+    index = closingIndex + tickCount;
+    textStart = index;
+  }
+
+  const tail = text.slice(textStart);
+  const replacedTail = replacePlainTokenInSegment(tail, token);
+  output += replacedTail.segment;
+  return output;
+}
+
+function replacePlainTokenInSegment(segment: string, token: string): { segment: string; replaced: boolean } {
+  const index = segment.indexOf(token);
+  if (index < 0) {
+    return { segment, replaced: false };
+  }
+
+  return {
+    segment: `${segment.slice(0, index)}\`${token}\`${segment.slice(index + token.length)}`,
+    replaced: true
+  };
 }
 
 function collectPlainCommandTokens(
@@ -1342,7 +1462,11 @@ async function translateProtectedSegment(
     injectedDraftText,
     chunkPromptContext.stateSlice
   );
-  const canonicalProtectedBody = reprotectMarkdownSpans(normalizedHeadingDraftText, combinedSpans);
+  const restoredInlineDraftText = restoreInlineCodeFromSourceShape(
+    protectedSource,
+    normalizedHeadingDraftText
+  );
+  const canonicalProtectedBody = reprotectMarkdownSpans(restoredInlineDraftText, combinedSpans);
   const restoredBody = restoreMarkdownSpans(canonicalProtectedBody, combinedSpans);
   applySegmentDraft(context.state, segmentId, {
     protectedSource,
@@ -1443,7 +1567,11 @@ async function repairDraftedSegment(
       normalizedHeadingRepairText,
       buildSegmentTaskSlice(context.state, context.chunkId, draftedSegment.segmentId)
     );
-    draftedSegment.protectedBody = reprotectMarkdownSpans(normalizedExplicitRepairText, draftedSegment.spans);
+    const restoredInlineRepairText = restoreInlineCodeFromSourceShape(
+      draftedSegment.protectedSource,
+      normalizedExplicitRepairText
+    );
+    draftedSegment.protectedBody = reprotectMarkdownSpans(restoredInlineRepairText, draftedSegment.spans);
     draftedSegment.restoredBody = restoreMarkdownSpans(draftedSegment.protectedBody, draftedSegment.spans);
     applyRepairResult(context.state, draftedSegment.segmentId, taskBatch.map((task) => task.id), {
       protectedBody: draftedSegment.protectedBody,

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -15,6 +15,7 @@ import {
   injectPlannedAnchorText,
   normalizeExplicitRepairAnchorText,
   normalizeHeadingLikeAnchorText,
+  normalizeSourceSurfaceAnchorText,
   normalizeSegmentAnchorText
 } from "./anchor-normalization.js";
 import { FormattingError, HardGateError } from "./errors.js";
@@ -807,6 +808,11 @@ function inferRepairAnchorId(
   const explicitTargets = extractExplicitEnglishTargetsFromMustFix([instruction]);
   for (const target of explicitTargets) {
     const normalizedTarget = target.toLowerCase();
+    const exactAnchor = anchors.find((anchor) => anchor.english.toLowerCase() === normalizedTarget);
+    if (exactAnchor) {
+      return exactAnchor.anchorId;
+    }
+
     const matchedAnchor = anchors.find(
       (anchor) =>
         normalizedTarget.includes(anchor.english.toLowerCase()) ||
@@ -814,6 +820,12 @@ function inferRepairAnchorId(
     );
     if (matchedAnchor) {
       return matchedAnchor.anchorId;
+    }
+  }
+
+  for (const anchor of anchors) {
+    if (containsWholePhraseInText(instruction, anchor.english)) {
+      return anchor.anchorId;
     }
   }
 
@@ -826,6 +838,19 @@ function inferRepairAnchorId(
     }
   }
   return null;
+}
+
+function containsWholePhraseInText(haystack: string, needle: string): boolean {
+  if (!needle) {
+    return false;
+  }
+
+  if (/[A-Za-z]/.test(needle)) {
+    const escapedNeedle = needle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return new RegExp(`\\b${escapedNeedle}\\b`, "i").test(haystack);
+  }
+
+  return haystack.includes(needle);
 }
 
 function inferRepairTargetEnglish(
@@ -1132,9 +1157,14 @@ async function translateProtectedChunk(
         hardPassProtectedSource,
         styleResult.text
       );
+      const normalizedSurfaceStyleText = normalizeSourceSurfaceAnchorText(
+        hardPassProtectedSource,
+        normalizedStyleText,
+        chunkStylePromptContext.stateSlice
+      );
       const restoredInlineStyleText = restoreInlineCodeFromSourceShape(
         hardPassProtectedSource,
-        normalizedStyleText
+        normalizedSurfaceStyleText
       );
       restoredChunkBody = restoreMarkdownSpans(restoredInlineStyleText, chunkSpans);
       if (looksLikeMetaTaskResponse(restoredChunkBody)) {
@@ -1462,9 +1492,14 @@ async function translateProtectedSegment(
     injectedDraftText,
     chunkPromptContext.stateSlice
   );
+  const normalizedSurfaceDraftText = normalizeSourceSurfaceAnchorText(
+    protectedSource,
+    normalizedHeadingDraftText,
+    chunkPromptContext.stateSlice
+  );
   const restoredInlineDraftText = restoreInlineCodeFromSourceShape(
     protectedSource,
-    normalizedHeadingDraftText
+    normalizedSurfaceDraftText
   );
   const canonicalProtectedBody = reprotectMarkdownSpans(restoredInlineDraftText, combinedSpans);
   const restoredBody = restoreMarkdownSpans(canonicalProtectedBody, combinedSpans);
@@ -1567,9 +1602,14 @@ async function repairDraftedSegment(
       normalizedHeadingRepairText,
       buildSegmentTaskSlice(context.state, context.chunkId, draftedSegment.segmentId)
     );
+    const normalizedSurfaceRepairText = normalizeSourceSurfaceAnchorText(
+      draftedSegment.protectedSource,
+      normalizedExplicitRepairText,
+      buildSegmentTaskSlice(context.state, context.chunkId, draftedSegment.segmentId)
+    );
     const restoredInlineRepairText = restoreInlineCodeFromSourceShape(
       draftedSegment.protectedSource,
-      normalizedExplicitRepairText
+      normalizedSurfaceRepairText
     );
     draftedSegment.protectedBody = reprotectMarkdownSpans(restoredInlineRepairText, draftedSegment.spans);
     draftedSegment.restoredBody = restoreMarkdownSpans(draftedSegment.protectedBody, draftedSegment.spans);

--- a/test/anchor-normalization.test.ts
+++ b/test/anchor-normalization.test.ts
@@ -308,3 +308,25 @@ test("normalizeExplicitRepairAnchorText preserves missing source heading qualifi
 
   assert.equal(normalized, "### 第 2 类：提示式（Prompted，Requires Permission）");
 });
+
+test("normalizeExplicitRepairAnchorText injects a named anchor back into a heading line", () => {
+  const slice = createSlice({
+    requiredAnchors: [createAnchor("anchor-1", "Sandbox Mode", "沙箱模式")],
+    pendingRepairs: [
+      {
+        repairId: "repair-1",
+        anchorId: "anchor-1",
+        failureType: "missing_anchor",
+        locationLabel: "标题",
+        instruction:
+          "位置：## 标题“沙箱模式如何改变自主编码”｜问题：首现术语 Sandbox Mode 未补中英文对照｜修复目标：在标题本身建立该术语的双语锚点。"
+      }
+    ]
+  });
+  const source = "## How Sandbox Mode Changes Autonomous Coding";
+  const translated = "## 沙箱模式如何改变自主编码";
+
+  const normalized = normalizeExplicitRepairAnchorText(source, translated, slice);
+
+  assert.equal(normalized, "## 沙箱模式（Sandbox Mode）如何改变自主编码");
+});

--- a/test/anchor-normalization.test.ts
+++ b/test/anchor-normalization.test.ts
@@ -246,3 +246,24 @@ test("normalizeExplicitRepairAnchorText restores a quoted-line anchor from an ex
 
   assert.equal(normalized, "> 现在让我们看看沙箱模式（Sandbox mode）会保护你免受什么影响。");
 });
+
+test("normalizeExplicitRepairAnchorText restores a heading-like anchor from a structured title repair target", () => {
+  const slice = createSlice({
+    pendingRepairs: [
+      {
+        repairId: "repair-1",
+        anchorId: null,
+        failureType: "missing_anchor",
+        locationLabel: "分段标题",
+        instruction:
+          "位置：分段标题“**测试 2：系统文件访问**”；问题：首次出现的关键术语“System File Access”缺少中英文对照；修复目标：在标题本身补齐该术语的英文锚定。"
+      }
+    ]
+  });
+  const source = "**Test 2: System File Access**";
+  const translated = "**测试 2：系统文件访问**";
+
+  const normalized = normalizeExplicitRepairAnchorText(source, translated, slice);
+
+  assert.equal(normalized, "**测试 2：系统文件访问（System File Access）**");
+});

--- a/test/anchor-normalization.test.ts
+++ b/test/anchor-normalization.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   formatAnchorDisplay,
+  injectPlannedAnchorText,
   normalizeExplicitRepairAnchorText,
   normalizeHeadingLikeAnchorText,
   normalizeSegmentAnchorText,
@@ -136,6 +137,54 @@ test("normalizeHeadingLikeAnchorText restores a missing english anchor inside a 
 
   assert.match(normalized, /\*\*测试 2：系统文件访问（System File Access）\*\*/);
   assert.match(normalized, /告诉 Claude：/);
+});
+
+test("injectPlannedAnchorText injects a missing anchor into a heading-like line", () => {
+  const slice = createSlice({
+    requiredAnchors: [createAnchor("anchor-1", "System File Access", "系统文件访问")]
+  });
+  const source = "**Test 2: System File Access**";
+  const translated = "**测试 2：系统文件访问**";
+
+  const normalized = injectPlannedAnchorText(source, translated, slice);
+
+  assert.equal(normalized, "**测试 2：系统文件访问（System File Access）**");
+});
+
+test("injectPlannedAnchorText injects a missing anchor into a list item", () => {
+  const slice = createSlice({
+    requiredAnchors: [createAnchor("anchor-1", "API tokens", "API 令牌")]
+  });
+  const source = "- API tokens";
+  const translated = "- API 令牌";
+
+  const normalized = injectPlannedAnchorText(source, translated, slice);
+
+  assert.equal(normalized, "- API 令牌（API tokens）");
+});
+
+test("injectPlannedAnchorText injects a missing anchor into a blockquote line", () => {
+  const slice = createSlice({
+    requiredAnchors: [createAnchor("anchor-1", "Sandbox mode", "沙箱模式")]
+  });
+  const source = "> Let's now look at what Sandbox mode protects you from.";
+  const translated = "> 现在让我们看看沙箱模式会保护你免受什么影响。";
+
+  const normalized = injectPlannedAnchorText(source, translated, slice);
+
+  assert.equal(normalized, "> 现在让我们看看沙箱模式（Sandbox mode）会保护你免受什么影响。");
+});
+
+test("injectPlannedAnchorText injects a missing anchor into a paragraph line", () => {
+  const slice = createSlice({
+    requiredAnchors: [createAnchor("anchor-1", "Prompt injection attacks", "提示注入攻击")]
+  });
+  const source = "Prompt injection attacks can hide malicious instructions.";
+  const translated = "提示注入攻击会隐藏恶意指令。";
+
+  const normalized = injectPlannedAnchorText(source, translated, slice);
+
+  assert.equal(normalized, "提示注入攻击（Prompt injection attacks）会隐藏恶意指令。");
 });
 
 test("normalizeExplicitRepairAnchorText restores a quoted-line anchor from an explicit repair target", () => {

--- a/test/anchor-normalization.test.ts
+++ b/test/anchor-normalization.test.ts
@@ -119,6 +119,19 @@ test("normalizeSegmentAnchorText reuses a better local english-primary hint when
   assert.doesNotMatch(normalized, /Claude（Claude）/);
 });
 
+test("normalizeSegmentAnchorText strips a trailing repeated english name from an english-primary explainer", () => {
+  const slice = createSlice({
+    requiredAnchors: [createAnchor("anchor-1", "Claude", "Anthropic 的 AI 助手 Claude")]
+  });
+
+  const normalized = normalizeSegmentAnchorText(
+    "这些内容默认会被阻止，即使 Claude（Anthropic 的 AI 助手 Claude）被指示要访问它们。",
+    slice
+  );
+
+  assert.equal(normalized, "这些内容默认会被阻止，即使 Claude（Anthropic 的 AI 助手）被指示要访问它们。");
+});
+
 test("normalizeSegmentAnchorText collapses duplicate English parentheses when no better local hint exists", () => {
   const slice = createSlice({
     requiredAnchors: []
@@ -329,4 +342,26 @@ test("normalizeExplicitRepairAnchorText injects a named anchor back into a headi
   const normalized = normalizeExplicitRepairAnchorText(source, translated, slice);
 
   assert.equal(normalized, "## 沙箱模式（Sandbox Mode）如何改变自主编码");
+});
+
+test("normalizeExplicitRepairAnchorText injects a named anchor back into a list item", () => {
+  const slice = createSlice({
+    requiredAnchors: [createAnchor("anchor-1", "Environment variables", "环境变量")],
+    pendingRepairs: [
+      {
+        repairId: "repair-1",
+        anchorId: "anchor-1",
+        failureType: "missing_anchor",
+        locationLabel: "列表项",
+        instruction:
+          "位置：第一段列表“包含秘密信息的环境变量”：Environment variables 首次出现需补中英文对照，不能只写中文。"
+      }
+    ]
+  });
+  const source = "- Environment variables containing secrets";
+  const translated = "- 包含秘密信息的环境变量";
+
+  const normalized = normalizeExplicitRepairAnchorText(source, translated, slice);
+
+  assert.equal(normalized, "- 包含秘密信息的环境变量（Environment variables）");
 });

--- a/test/anchor-normalization.test.ts
+++ b/test/anchor-normalization.test.ts
@@ -267,3 +267,23 @@ test("normalizeExplicitRepairAnchorText restores a heading-like anchor from a st
 
   assert.equal(normalized, "**测试 2：系统文件访问（System File Access）**");
 });
+
+test("normalizeExplicitRepairAnchorText falls back to the source ATX heading when the repair target omits english", () => {
+  const slice = createSlice({
+    pendingRepairs: [
+      {
+        repairId: "repair-1",
+        anchorId: null,
+        failureType: "missing_anchor",
+        locationLabel: "小标题",
+        instruction: "`### 凭证窃取`：这是本分段首次出现的关键术语，小标题需补英文对照后再用。"
+      }
+    ]
+  });
+  const source = "### Credential Theft";
+  const translated = "### 凭证窃取";
+
+  const normalized = normalizeExplicitRepairAnchorText(source, translated, slice);
+
+  assert.equal(normalized, "### 凭证窃取（Credential Theft）");
+});

--- a/test/anchor-normalization.test.ts
+++ b/test/anchor-normalization.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeExplicitRepairAnchorText,
   normalizeHeadingLikeAnchorText,
   normalizeSegmentAnchorText,
+  normalizeSourceSurfaceAnchorText,
   type PromptAnchor
 } from "../src/anchor-normalization.js";
 import type { PromptSlice } from "../src/translation-state.js";
@@ -130,6 +131,19 @@ test("normalizeSegmentAnchorText strips a trailing repeated english name from an
   );
 
   assert.equal(normalized, "这些内容默认会被阻止，即使 Claude（Anthropic 的 AI 助手）被指示要访问它们。");
+});
+
+test("normalizeSourceSurfaceAnchorText keeps the source surface form when a longer family variant appears in translation", () => {
+  const slice = createSlice({
+    requiredAnchors: [createAnchor("anchor-1", "Claude", "Anthropic 的 AI 助手", "claude-family")],
+    establishedAnchors: [createAnchor("anchor-2", "Claude Code", "Claude Code", "claude-family")]
+  });
+  const source = "Tell Claude:";
+  const translated = "告诉 Claude Code（Claude）：";
+
+  const normalized = normalizeSourceSurfaceAnchorText(source, translated, slice);
+
+  assert.equal(normalized, "告诉 Claude（Anthropic 的 AI 助手）：");
 });
 
 test("normalizeSegmentAnchorText collapses duplicate English parentheses when no better local hint exists", () => {

--- a/test/anchor-normalization.test.ts
+++ b/test/anchor-normalization.test.ts
@@ -105,6 +105,30 @@ test("normalizeSegmentAnchorText preserves english-primary tool anchors with a c
   assert.equal(normalized, "Linux 上的 bubblewrap（安全隔离组件）提供了隔离能力。");
 });
 
+test("normalizeSegmentAnchorText reuses a better local english-primary hint when a duplicate English parenthesis appears", () => {
+  const slice = createSlice({
+    requiredAnchors: []
+  });
+
+  const normalized = normalizeSegmentAnchorText(
+    "它会移除所有提示，但也会取消所有保护。Claude（Claude）可以访问任何文件。\n- Claude（AI 助手）在你的项目文件夹里创建一个文件？这需要批准。",
+    slice
+  );
+
+  assert.match(normalized, /Claude（AI 助手）可以访问任何文件。/);
+  assert.doesNotMatch(normalized, /Claude（Claude）/);
+});
+
+test("normalizeSegmentAnchorText collapses duplicate English parentheses when no better local hint exists", () => {
+  const slice = createSlice({
+    requiredAnchors: []
+  });
+
+  const normalized = normalizeSegmentAnchorText("Claude（Claude）可以访问任何文件。", slice);
+
+  assert.equal(normalized, "Claude可以访问任何文件。");
+});
+
 test("formatAnchorDisplay prefers english-primary formatting for single-token tool names", () => {
   assert.equal(formatAnchorDisplay(createAnchor("anchor-1", "bubblewrap", "安全隔离组件")), "bubblewrap（安全隔离组件）");
   assert.equal(formatAnchorDisplay(createAnchor("anchor-2", "bubblewrap", "bubblewrap 框架")), "bubblewrap（框架）");

--- a/test/anchor-normalization.test.ts
+++ b/test/anchor-normalization.test.ts
@@ -187,6 +187,21 @@ test("injectPlannedAnchorText injects a missing anchor into a paragraph line", (
   assert.equal(normalized, "提示注入攻击（Prompt injection attacks）会隐藏恶意指令。");
 });
 
+test("injectPlannedAnchorText does not expand command phrases inside Commands-style list items", () => {
+  const slice = createSlice({
+    requiredAnchors: [
+      createAnchor("anchor-1", "Git", "版本控制工具"),
+      createAnchor("anchor-2", "Python", "python")
+    ]
+  });
+  const source = ["- git status, git log, git diff", "- python script.py (runs code in project)"].join("\n");
+  const translated = ["- git status、git log、git diff", "- python script.py（在项目中运行代码）"].join("\n");
+
+  const normalized = injectPlannedAnchorText(source, translated, slice);
+
+  assert.equal(normalized, translated);
+});
+
 test("normalizeExplicitRepairAnchorText restores a quoted-line anchor from an explicit repair target", () => {
   const slice = createSlice({
     pendingRepairs: [

--- a/test/anchor-normalization.test.ts
+++ b/test/anchor-normalization.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  formatAnchorDisplay,
   normalizeExplicitRepairAnchorText,
   normalizeHeadingLikeAnchorText,
   normalizeSegmentAnchorText,
@@ -75,6 +76,41 @@ test("normalizeSegmentAnchorText collapses exact duplicate english-only parenthe
   const normalized = normalizeSegmentAnchorText("npm（npm） registry access is allowed.", slice);
 
   assert.equal(normalized, "npm registry access is allowed.");
+});
+
+test("normalizeSegmentAnchorText rewrites english-leading duplicated anchor text into english-primary form", () => {
+  const slice = createSlice({
+    requiredAnchors: [createAnchor("anchor-1", "bubblewrap", "bubblewrap 框架")]
+  });
+
+  const normalized = normalizeSegmentAnchorText(
+    "Linux 上的 bubblewrap 框架（bubblewrap）提供了隔离能力。",
+    slice
+  );
+
+  assert.equal(normalized, "Linux 上的 bubblewrap（框架）提供了隔离能力。");
+});
+
+test("normalizeSegmentAnchorText preserves english-primary tool anchors with a chinese explanation", () => {
+  const slice = createSlice({
+    requiredAnchors: [createAnchor("anchor-1", "bubblewrap", "安全隔离组件")]
+  });
+
+  const normalized = normalizeSegmentAnchorText(
+    "Linux 上的 bubblewrap（安全隔离组件）提供了隔离能力。",
+    slice
+  );
+
+  assert.equal(normalized, "Linux 上的 bubblewrap（安全隔离组件）提供了隔离能力。");
+});
+
+test("formatAnchorDisplay prefers english-primary formatting for single-token tool names", () => {
+  assert.equal(formatAnchorDisplay(createAnchor("anchor-1", "bubblewrap", "安全隔离组件")), "bubblewrap（安全隔离组件）");
+  assert.equal(formatAnchorDisplay(createAnchor("anchor-2", "bubblewrap", "bubblewrap 框架")), "bubblewrap（框架）");
+  assert.equal(
+    formatAnchorDisplay(createAnchor("anchor-3", "Prompt injection attacks", "提示注入攻击")),
+    "提示注入攻击（Prompt injection attacks）"
+  );
 });
 
 test("normalizeHeadingLikeAnchorText restores a missing english anchor inside a bold pseudo-heading", () => {

--- a/test/anchor-normalization.test.ts
+++ b/test/anchor-normalization.test.ts
@@ -287,3 +287,24 @@ test("normalizeExplicitRepairAnchorText falls back to the source ATX heading whe
 
   assert.equal(normalized, "### 凭证窃取（Credential Theft）");
 });
+
+test("normalizeExplicitRepairAnchorText preserves missing source heading qualifiers inside an existing heading parenthesis", () => {
+  const slice = createSlice({
+    pendingRepairs: [
+      {
+        repairId: "repair-1",
+        anchorId: null,
+        failureType: "missing_anchor",
+        locationLabel: "小标题",
+        instruction:
+          "位置：### 第 2 类：提示式（Prompted）。问题：缺少源文标题括注“Requires Permission”的对应信息。修复目标：补齐该标题的中英文对照，且不改动结构。"
+      }
+    ]
+  });
+  const source = "### Category 2: Prompted (Requires Permission)";
+  const translated = "### 第 2 类：提示式（Prompted）";
+
+  const normalized = normalizeExplicitRepairAnchorText(source, translated, slice);
+
+  assert.equal(normalized, "### 第 2 类：提示式（Prompted，Requires Permission）");
+});

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -2545,6 +2545,65 @@ test("translateMarkdownArticle repairs multiple must_fix items one at a time", a
   ]);
 });
 
+test("translateMarkdownArticle batches mixed-location repairs in the same segment together", async () => {
+  const source = [
+    "# Title",
+    "",
+    "> Quote line",
+    "",
+    "- List item one",
+    "- List item two",
+    ""
+  ].join("\n");
+  const repairMustFixSections: string[] = [];
+  let auditCallCount = 0;
+
+  const executor: CodexExecutor = {
+    async execute(prompt, options) {
+      if (prompt.includes("【must_fix】")) {
+        const mustFixSection = extractPromptSection(prompt, "【must_fix】") ?? "";
+        repairMustFixSections.push(mustFixSection.trim());
+        return createExecResult(source);
+      }
+
+      if (prompt.includes("只做“风格与可读性润色”")) {
+        return createExecResult(source);
+      }
+
+      if (options.outputSchema && prompt.includes("【分段审校输入】")) {
+        auditCallCount += 1;
+        const audit = auditCallCount === 1
+          ? createAudit(false, [
+              "第 1、2 条列表项中的 `Claude` 需要在本段首次出现处补中英文对照，不能只保留英文。",
+              "最后一条引用中的 `Sandbox mode` 需要补英文原名对应关系，不能只译成“沙盒模式”。"
+            ])
+          : createAudit(true);
+        return createExecResult(
+          wrapPerSegmentAudits(prompt, [{ segment_index: 1, audit }])
+        );
+      }
+
+      if (options.outputSchema || prompt.includes("只返回 JSON")) {
+        return createExecResult(JSON.stringify(createAudit(true)));
+      }
+
+      return createExecResult(source);
+    }
+  };
+
+  await translateMarkdownArticle(source, {
+    executor,
+    formatter: async (markdown) => markdown
+  });
+
+  assert.deepEqual(repairMustFixSections, [
+    [
+      "- 第 1、2 条列表项中的 `Claude` 需要在本段首次出现处补中英文对照，不能只保留英文。",
+      "- 最后一条引用中的 `Sandbox mode` 需要补英文原名对应关系，不能只译成“沙盒模式”。"
+    ].join("\n")
+  ]);
+});
+
 test("translateMarkdownArticle repeats slash-qualified heading repair guidance when must_fix targets a heading", async () => {
   const source = [
     "# Title",

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -753,6 +753,51 @@ test("translateMarkdownArticle strips added inline code from multi-command phras
   assert.doesNotMatch(result.markdown, /`python script\.py`/);
 });
 
+test("translateMarkdownArticle restores inline code only at source locations when the same flag also appears as plain text", async () => {
+  const source = [
+    "## Claude Code Permission Problem",
+    "",
+    "If you use the --dangerously-skip-permissions flag, you remove safety guardrails.",
+    "",
+    "The `--dangerously-skip-permissions` flag exists as an escape hatch from this fatigue."
+  ].join("\n");
+
+  class MixedFlagExecutor implements CodexExecutor {
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(createEmptyAnchorCatalog());
+      }
+
+      if (options.outputSchema || prompt.includes('"hard_checks"') || prompt.includes("只返回 JSON")) {
+        return createExecResult(wrapAuditForSegments(prompt, createAudit(true)));
+      }
+
+      const translated = [
+        "## Claude Code 权限问题",
+        "",
+        "如果你使用 --dangerously-skip-permissions 标志，就会移除安全护栏。",
+        "",
+        "这个 --dangerously-skip-permissions 标志是为了缓解这种疲劳而存在的逃生舱。"
+      ].join("\n");
+
+      if (prompt.includes("只做“风格与可读性润色”")) {
+        return createExecResult(extractPromptSection(prompt, "【当前译文】") ?? translated);
+      }
+
+      return createExecResult(translated);
+    }
+  }
+
+  const result = await translateMarkdownArticle(source, {
+    executor: new MixedFlagExecutor(),
+    formatter: async (markdown) => markdown
+  });
+
+  assert.match(result.markdown, /如果你使用 --dangerously-skip-permissions 标志/);
+  assert.match(result.markdown, /这个 `--dangerously-skip-permissions` 标志是为了缓解这种疲劳而存在的逃生舱/);
+  assert.doesNotMatch(result.markdown, /如果你使用 `--dangerously-skip-permissions` 标志/);
+});
+
 test("translateMarkdownArticle runs the hidden pipeline chunk by chunk for long Markdown sections", async () => {
   const source = [
     "# Title",

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -2190,6 +2190,86 @@ test("translateMarkdownArticle repeats sentence-local repair guidance when must_
   assert.match(repairPrompt, /不要把锚定转移到同段其他句子、标题、列表项、引用外说明或后续段落/);
 });
 
+test("translateMarkdownArticle keeps sentence-local Claude repairs away from earlier Claude Code anchors", async () => {
+  const source = [
+    "# Title",
+    "",
+    "## Earlier",
+    "",
+    `${"Claude Code is already established here. ".repeat(240)}`,
+    "",
+    "## External API Access",
+    "",
+    "**Test 4: External API Access (Should Prompt First Time)**",
+    "",
+    "Tell Claude:",
+    ""
+  ].join("\n");
+
+  class PriorAnchorExecutor extends PromptAwareExecutor {
+    override async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      this.prompts.push(prompt);
+
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(
+          createAnchorCatalog([
+            {
+              english: "Claude Code",
+              chineseHint: "Claude Code",
+              familyKey: "claude code",
+              chunkId: "chunk-1",
+              segmentId: "chunk-1-segment-1"
+            }
+          ])
+        );
+      }
+
+      if (options.outputSchema && prompt.includes("【分段审校输入】") && prompt.includes("Tell Claude:")) {
+        return createExecResult(
+          wrapPerSegmentAudits(prompt, [
+            {
+              segment_index: 1,
+              audit: createAudit(false, [
+                "第4段末句“告诉 Claude Code（Claude）”与原文“Tell Claude:”不一致；需保持原文专名 Claude 的对应，不要额外加入 Code。"
+              ])
+            }
+          ])
+        );
+      }
+
+      if (options.outputSchema || prompt.includes("只返回 JSON")) {
+        return createExecResult(wrapAuditForSegments(prompt, createAudit(true)));
+      }
+
+      const currentTranslation = extractPromptSection(prompt, "【当前译文】");
+      if (currentTranslation !== null) {
+        return createExecResult(currentTranslation);
+      }
+
+      const sourceSection = extractPromptSection(prompt, "【英文原文】");
+      return createExecResult(sourceSection ?? "");
+    }
+  }
+
+  const executor = new PriorAnchorExecutor();
+  await translateMarkdownArticle(source, {
+    executor,
+    formatter: async (markdown) => markdown
+  });
+
+  const repairPrompt = executor.prompts.find(
+    (item) =>
+      item.includes("【must_fix】") &&
+      item.includes("Tell Claude:") &&
+      item.includes("不要额外加入 Code")
+  );
+  assert.ok(repairPrompt);
+  assert.match(repairPrompt, /必须把这句视为唯一有效落点/);
+  assert.match(repairPrompt, /不要把锚定转移到同段其他句子、标题、列表项、引用外说明或后续段落/);
+  assert.doesNotMatch(repairPrompt, /本次 must_fix 明确指向标题/);
+  assert.doesNotMatch(repairPrompt, /本次 must_fix 明确点名了这些英文目标：.*Claude Code/);
+});
+
 test("translateMarkdownArticle tells repair when the same anchor is still missing in multiple locations", async () => {
   const source = [
     "## So, What Do AI Agents Need?",

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -3082,6 +3082,56 @@ test("translateMarkdownArticle restores an ATX heading anchor after repair when 
   assert.match(result.markdown, /### 凭证窃取（Credential Theft）/);
 });
 
+test("translateMarkdownArticle restores missing source heading qualifiers inside category-style headings", async () => {
+  const source = [
+    "# Title",
+    "",
+    "### Category 2: Prompted (Requires Permission)",
+    "",
+    "Body.",
+    ""
+  ].join("\n");
+
+  let auditCount = 0;
+  const result = await translateMarkdownArticle(source, {
+    executor: {
+      async execute(prompt, options) {
+        if (options.outputSchema && prompt.includes("【分段审校输入】")) {
+          auditCount += 1;
+          if (auditCount === 1) {
+            return createExecResult(
+              wrapPerSegmentAudits(prompt, [
+                {
+                  segment_index: 1,
+                  audit: createAudit(false, [
+                    "位置：### 第 2 类：提示式（Prompted）。问题：缺少源文标题括注“Requires Permission”的对应信息。修复目标：补齐该标题的中英文对照，且不改动结构。"
+                  ])
+                }
+              ])
+            );
+          }
+
+          return createExecResult(wrapPerSegmentAudits(prompt, [{ segment_index: 1, audit: createAudit(true) }]));
+        }
+
+        if (options.outputSchema || prompt.includes("只返回 JSON")) {
+          return createExecResult(JSON.stringify(createAudit(true)));
+        }
+
+        const currentTranslation = extractPromptSection(prompt, "【当前译文】");
+        if (currentTranslation !== null) {
+          return createExecResult(currentTranslation);
+        }
+
+        return createExecResult(["# Title", "", "### 第 2 类：提示式（Prompted）", "", "正文。", ""].join("\n"));
+      }
+    },
+    formatter: async (markdown) => markdown
+  });
+
+  assert.match(result.markdown, /### 第 2 类：提示式（Prompted，Requires Permission）/);
+});
+
 test("translateMarkdownArticle adds attribution guidance for caption-like segments", async () => {
   const source = [
     "# Title",

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -705,6 +705,54 @@ test("translateMarkdownArticle strips added inline code from plain command list 
   assert.doesNotMatch(result.markdown, /`sudo`/);
 });
 
+test("translateMarkdownArticle strips added inline code from multi-command phrases under Commands", async () => {
+  const source = [
+    "### Category 1: Auto-Allowed",
+    "",
+    "**Commands:**",
+    "",
+    "- git status, git log, git diff",
+    "- npm install, npm test, npm run",
+    "- ls, cat, echo, basic shell commands",
+    "- python script.py (runs code in project)"
+  ].join("\n");
+
+  class MultiCommandExecutor implements CodexExecutor {
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (options.outputSchema || prompt.includes('"hard_checks"') || prompt.includes("只返回 JSON")) {
+        return createExecResult(wrapAuditForSegments(prompt, createAudit(true)));
+      }
+
+      const translated = [
+        "### 第 1 类：自动允许",
+        "",
+        "**命令（Commands）：**",
+        "",
+        "- `git status`、`git log`、`git diff`",
+        "- `npm install`、`npm test`、`npm run`",
+        "- ls、`cat`、`echo`、基础 shell 命令",
+        "- `python script.py`（在项目中运行代码）"
+      ].join("\n");
+
+      return createExecResult(translated);
+    }
+  }
+
+  const result = await translateMarkdownArticle(source, {
+    executor: new MultiCommandExecutor(),
+    formatter: async (markdown) => markdown
+  });
+
+  assert.match(result.markdown, /- git status、git log、git diff/);
+  assert.match(result.markdown, /- npm install、npm test、npm run/);
+  assert.match(result.markdown, /- ls、cat、echo、基础 shell 命令/);
+  assert.match(result.markdown, /- python script\.py（在项目中运行代码）/);
+  assert.doesNotMatch(result.markdown, /`git status`/);
+  assert.doesNotMatch(result.markdown, /`npm install`/);
+  assert.doesNotMatch(result.markdown, /`cat`/);
+  assert.doesNotMatch(result.markdown, /`python script\.py`/);
+});
+
 test("translateMarkdownArticle runs the hidden pipeline chunk by chunk for long Markdown sections", async () => {
   const source = [
     "# Title",

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -3132,6 +3132,68 @@ test("translateMarkdownArticle restores missing source heading qualifiers inside
   assert.match(result.markdown, /### 第 2 类：提示式（Prompted，Requires Permission）/);
 });
 
+test("translateMarkdownArticle restores a named anchor inside an ATX heading after repair", async () => {
+  const source = [
+    "# Title",
+    "",
+    "## How Sandbox Mode Changes Autonomous Coding",
+    "",
+    "Body.",
+    ""
+  ].join("\n");
+
+  let auditCount = 0;
+  const result = await translateMarkdownArticle(source, {
+    executor: {
+      async execute(prompt, options) {
+        if (isDocumentAnalysisPrompt(prompt)) {
+          return createExecResult(
+            createAnchorCatalog([
+              {
+                english: "Sandbox Mode",
+                chineseHint: "沙箱模式",
+                familyKey: "sandbox-mode"
+              }
+            ])
+          );
+        }
+
+        if (options.outputSchema && prompt.includes("【分段审校输入】")) {
+          auditCount += 1;
+          if (auditCount === 1) {
+            return createExecResult(
+              wrapPerSegmentAudits(prompt, [
+                {
+                  segment_index: 1,
+                  audit: createAudit(false, [
+                    "位置：## 标题“沙箱模式如何改变自主编码”｜问题：首现术语 Sandbox Mode 未补中英文对照｜修复目标：在标题本身建立该术语的双语锚点。"
+                  ])
+                }
+              ])
+            );
+          }
+
+          return createExecResult(wrapPerSegmentAudits(prompt, [{ segment_index: 1, audit: createAudit(true) }]));
+        }
+
+        if (options.outputSchema || prompt.includes("只返回 JSON")) {
+          return createExecResult(JSON.stringify(createAudit(true)));
+        }
+
+        const currentTranslation = extractPromptSection(prompt, "【当前译文】");
+        if (currentTranslation !== null) {
+          return createExecResult(currentTranslation);
+        }
+
+        return createExecResult(["# Title", "", "## 沙箱模式如何改变自主编码", "", "正文。", ""].join("\n"));
+      }
+    },
+    formatter: async (markdown) => markdown
+  });
+
+  assert.match(result.markdown, /## 沙箱模式（Sandbox Mode）如何改变自主编码/);
+});
+
 test("translateMarkdownArticle adds attribution guidance for caption-like segments", async () => {
   const source = [
     "# Title",

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -2363,6 +2363,64 @@ test("translateMarkdownArticle keeps sentence-local Claude repairs away from ear
   assert.doesNotMatch(repairPrompt, /本次 must_fix 明确点名了这些英文目标：.*Claude Code/);
 });
 
+test("translateMarkdownArticle keeps the source surface form when Claude and Claude Code share a family", async () => {
+  const source = [
+    "# Title",
+    "",
+    "Claude Code is already established earlier in this segment.",
+    "",
+    "Tell Claude:"
+  ].join("\n");
+
+  class ClaudeSurfaceExecutor extends PromptAwareExecutor {
+    override async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      this.prompts.push(prompt);
+
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(
+          createAnchorCatalog([
+            {
+              english: "Claude Code",
+              chineseHint: "Claude Code",
+              familyKey: "claude-family"
+            },
+            {
+              english: "Claude",
+              chineseHint: "Anthropic 的 AI 助手",
+              familyKey: "claude-family"
+            }
+          ])
+        );
+      }
+
+      if (options.outputSchema || prompt.includes("只返回 JSON")) {
+        return createExecResult(wrapAuditForSegments(prompt, createAudit(true)));
+      }
+
+      const currentTranslation = extractPromptSection(prompt, "【当前译文】");
+      if (currentTranslation !== null) {
+        return createExecResult(currentTranslation);
+      }
+
+      return createExecResult([
+        "# 标题",
+        "",
+        "Claude Code 已在本段前文建立。",
+        "",
+        "告诉 Claude Code（Claude）："
+      ].join("\n"));
+    }
+  }
+
+  const result = await translateMarkdownArticle(source, {
+    executor: new ClaudeSurfaceExecutor(),
+    formatter: async (markdown) => markdown
+  });
+
+  assert.match(result.markdown, /告诉 Claude（Anthropic 的 AI 助手）：/);
+  assert.doesNotMatch(result.markdown, /Claude Code（Claude）/);
+});
+
 test("translateMarkdownArticle tells repair when the same anchor is still missing in multiple locations", async () => {
   const source = [
     "## So, What Do AI Agents Need?",

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -2969,6 +2969,69 @@ test("translateMarkdownArticle adds numbered bold-heading guidance for colon-qua
   assert.match(repairPrompt, /完整保留 `Test 2`、`Step 1`、`Example` 这类前导结构/);
 });
 
+test("translateMarkdownArticle restores a structured heading-like anchor after repair even when the model leaves the title unchanged", async () => {
+  const source = [
+    "# Title",
+    "",
+    "**Test 2: System File Access**",
+    "",
+    "Tell Claude:",
+    "",
+    "Read my .bashrc file and show me the first 5 lines.",
+    ""
+  ].join("\n");
+
+  let auditCount = 0;
+  const result = await translateMarkdownArticle(source, {
+    executor: {
+      async execute(prompt, options) {
+        if (options.outputSchema && prompt.includes("【分段审校输入】")) {
+          auditCount += 1;
+          if (auditCount === 1) {
+            return createExecResult(
+              wrapPerSegmentAudits(prompt, [
+                {
+                  segment_index: 1,
+                  audit: createAudit(false, [
+                    "位置：分段标题“**测试 2：系统文件访问**”；问题：首次出现的关键术语“System File Access”缺少中英文对照；修复目标：在标题本身补齐该术语的英文锚定。"
+                  ])
+                }
+              ])
+            );
+          }
+
+          return createExecResult(wrapPerSegmentAudits(prompt, [{ segment_index: 1, audit: createAudit(true) }]));
+        }
+
+        if (options.outputSchema || prompt.includes("只返回 JSON")) {
+          return createExecResult(JSON.stringify(createAudit(true)));
+        }
+
+        const currentTranslation = extractPromptSection(prompt, "【当前译文】");
+        if (currentTranslation !== null) {
+          return createExecResult(currentTranslation);
+        }
+
+        return createExecResult(
+          [
+            "# Title",
+            "",
+            "**测试 2：系统文件访问**",
+            "",
+            "告诉 Claude：",
+            "",
+            "读取我的 `.bashrc` 文件，并显示前 5 行。",
+            ""
+          ].join("\n")
+        );
+      }
+    },
+    formatter: async (markdown) => markdown
+  });
+
+  assert.match(result.markdown, /\*\*测试 2：系统文件访问（System File Access）\*\*/);
+});
+
 test("translateMarkdownArticle adds attribution guidance for caption-like segments", async () => {
   const source = [
     "# Title",

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -3032,6 +3032,56 @@ test("translateMarkdownArticle restores a structured heading-like anchor after r
   assert.match(result.markdown, /\*\*测试 2：系统文件访问（System File Access）\*\*/);
 });
 
+test("translateMarkdownArticle restores an ATX heading anchor after repair when must_fix only names the translated heading", async () => {
+  const source = [
+    "# Title",
+    "",
+    "### Credential Theft",
+    "",
+    "Attempts to access:",
+    ""
+  ].join("\n");
+
+  let auditCount = 0;
+  const result = await translateMarkdownArticle(source, {
+    executor: {
+      async execute(prompt, options) {
+        if (options.outputSchema && prompt.includes("【分段审校输入】")) {
+          auditCount += 1;
+          if (auditCount === 1) {
+            return createExecResult(
+              wrapPerSegmentAudits(prompt, [
+                {
+                  segment_index: 1,
+                  audit: createAudit(false, [
+                    "`### 凭证窃取`：这是本分段首次出现的关键术语，小标题需补英文对照后再用。"
+                  ])
+                }
+              ])
+            );
+          }
+
+          return createExecResult(wrapPerSegmentAudits(prompt, [{ segment_index: 1, audit: createAudit(true) }]));
+        }
+
+        if (options.outputSchema || prompt.includes("只返回 JSON")) {
+          return createExecResult(JSON.stringify(createAudit(true)));
+        }
+
+        const currentTranslation = extractPromptSection(prompt, "【当前译文】");
+        if (currentTranslation !== null) {
+          return createExecResult(currentTranslation);
+        }
+
+        return createExecResult(["# Title", "", "### 凭证窃取", "", "尝试访问：", ""].join("\n"));
+      }
+    },
+    formatter: async (markdown) => markdown
+  });
+
+  assert.match(result.markdown, /### 凭证窃取（Credential Theft）/);
+});
+
 test("translateMarkdownArticle adds attribution guidance for caption-like segments", async () => {
   const source = [
     "# Title",

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -3198,7 +3198,7 @@ test("translateMarkdownArticle injects structured anchor state into draft prompt
 
   const draftPrompt = prompts.find((prompt) => prompt.includes("当前分段必须建立的首现锚点"));
   assert.ok(draftPrompt);
-  assert.match(draftPrompt, /提示注入攻击 \/ Prompt injection attacks/);
+  assert.match(draftPrompt, /提示注入攻击（Prompt injection attacks）/);
   assert.match(draftPrompt, /【状态切片\(JSON\)】/);
 });
 

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -3330,6 +3330,47 @@ test("translateMarkdownArticle injects structured anchor state into draft prompt
   assert.match(draftPrompt, /【状态切片\(JSON\)】/);
 });
 
+test("translateMarkdownArticle injects required anchors into list items before hard gate", async () => {
+  const source = "- API tokens\n";
+  let auditedTranslation = "";
+
+  const executor: CodexExecutor = {
+    async execute(prompt, options) {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(
+          createAnchorCatalog([
+            {
+              english: "API tokens",
+              chineseHint: "API 令牌",
+              familyKey: "api tokens"
+            }
+          ])
+        );
+      }
+
+      if (options.outputSchema || prompt.includes('"hard_checks"') || prompt.includes("只返回 JSON")) {
+        auditedTranslation = extractPromptSection(prompt, "【当前译文】") ?? "";
+        return createExecResult(wrapAuditForSegments(prompt, createAudit(true)));
+      }
+
+      const currentTranslation = extractPromptSection(prompt, "【当前译文】");
+      if (currentTranslation !== null) {
+        return createExecResult(currentTranslation);
+      }
+
+      return createExecResult("- API 令牌");
+    }
+  };
+
+  const output = await translateMarkdownArticle(source, {
+    executor,
+    formatter: async (markdown) => markdown
+  });
+
+  assert.match(auditedTranslation, /- API 令牌（API tokens）/);
+  assert.match(output.markdown, /- API 令牌（API tokens）/);
+});
+
 test("translateMarkdownArticle exports debug state when MDZH_DEBUG_STATE_PATH is set", async () => {
   const tempDir = await mkdtemp(path.join(tmpdir(), "mdzh-state-"));
   const debugPath = path.join(tempDir, "state.json");

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -3596,6 +3596,63 @@ test("translateMarkdownArticle injects required anchors into list items before h
   assert.match(output.markdown, /- API 令牌（API tokens）/);
 });
 
+test("translateMarkdownArticle restores a required anchor inside a longer list item after explicit repair", async () => {
+  const source = "- Environment variables containing secrets\n";
+  let auditCount = 0;
+
+  const executor: CodexExecutor = {
+    async execute(prompt, options) {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(
+          createAnchorCatalog([
+            {
+              english: "Environment variables",
+              chineseHint: "环境变量",
+              familyKey: "environment variables"
+            }
+          ])
+        );
+      }
+
+      if (options.outputSchema && prompt.includes("【分段审校输入】")) {
+        auditCount += 1;
+        if (auditCount === 1) {
+          return createExecResult(
+            wrapPerSegmentAudits(prompt, [
+              {
+                segment_index: 1,
+                audit: createAudit(false, [
+                  "位置：第一段列表“包含秘密信息的环境变量”：Environment variables 首次出现需补中英文对照，不能只写中文。"
+                ])
+              }
+            ])
+          );
+        }
+
+        return createExecResult(wrapPerSegmentAudits(prompt, [{ segment_index: 1, audit: createAudit(true) }]));
+      }
+
+      if (options.outputSchema || prompt.includes('"hard_checks"') || prompt.includes("只返回 JSON")) {
+        return createExecResult(JSON.stringify(createAudit(true)));
+      }
+
+      const currentTranslation = extractPromptSection(prompt, "【当前译文】");
+      if (currentTranslation !== null) {
+        return createExecResult(currentTranslation);
+      }
+
+      return createExecResult("- 包含秘密信息的环境变量");
+    }
+  };
+
+  const output = await translateMarkdownArticle(source, {
+    executor,
+    formatter: async (markdown) => markdown
+  });
+
+  assert.match(output.markdown, /- 包含秘密信息的环境变量（Environment variables）/);
+});
+
 test("translateMarkdownArticle does not inject required anchors into command phrases", async () => {
   const source = ["**Commands:**", "", "- git status, git log, git diff", "- python script.py (runs code in project)", ""].join(
     "\n"

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -3371,6 +3371,58 @@ test("translateMarkdownArticle injects required anchors into list items before h
   assert.match(output.markdown, /- API 令牌（API tokens）/);
 });
 
+test("translateMarkdownArticle does not inject required anchors into command phrases", async () => {
+  const source = ["**Commands:**", "", "- git status, git log, git diff", "- python script.py (runs code in project)", ""].join(
+    "\n"
+  );
+  let auditedTranslation = "";
+
+  const executor: CodexExecutor = {
+    async execute(prompt, options) {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(
+          createAnchorCatalog([
+            {
+              english: "Git",
+              chineseHint: "版本控制工具",
+              familyKey: "git"
+            },
+            {
+              english: "Python",
+              chineseHint: "python",
+              familyKey: "python"
+            }
+          ])
+        );
+      }
+
+      if (options.outputSchema || prompt.includes('"hard_checks"') || prompt.includes("只返回 JSON")) {
+        auditedTranslation = extractPromptSection(prompt, "【当前译文】") ?? "";
+        return createExecResult(wrapAuditForSegments(prompt, createAudit(true)));
+      }
+
+      const currentTranslation = extractPromptSection(prompt, "【当前译文】");
+      if (currentTranslation !== null) {
+        return createExecResult(currentTranslation);
+      }
+
+      return createExecResult(["**命令（Commands）：**", "", "- git status、git log、git diff", "- python script.py（在项目中运行代码）"].join("\n"));
+    }
+  };
+
+  const output = await translateMarkdownArticle(source, {
+    executor,
+    formatter: async (markdown) => markdown
+  });
+
+  assert.match(auditedTranslation, /- git status、git log、git diff/);
+  assert.match(auditedTranslation, /- python script\.py（在项目中运行代码）/);
+  assert.doesNotMatch(auditedTranslation, /Git（版本控制工具）status/);
+  assert.doesNotMatch(auditedTranslation, /Python（python）脚本 script\.py/);
+  assert.match(output.markdown, /- git status、git log、git diff/);
+  assert.match(output.markdown, /- python script\.py（在项目中运行代码）/);
+});
+
 test("translateMarkdownArticle exports debug state when MDZH_DEBUG_STATE_PATH is set", async () => {
   const tempDir = await mkdtemp(path.join(tmpdir(), "mdzh-state-"));
   const debugPath = path.join(tempDir, "state.json");


### PR DESCRIPTION
## 目的
- 交付 `#100` 的结构化翻译状态机重构。
- 合并 `#112` 到 `#126` 这一串 linked bug 修复，把真实长文回归打通。

## 范围
- 引入结构化运行状态，程序维护 chunk / segment / anchor / repair / protected span。
- 将首现中英对照从 prompt 近似规则逐步收敛到程序级 anchor plan / display policy / source surface form 约束。
- 修复真实长文回归中暴露的一系列工程边界问题，包括：
  - 多位置 repair 落点
  - heading-like / ATX heading 锚点回填
  - 命令短语与 plain command / inline code 边界
  - link placeholder / inline markdown link / source surface form 约束
  - duplicate english parentheses 与 english-primary anchor 显示策略

## 验证
- `npm test -- test/anchor-normalization.test.ts test/translate.test.ts --test-name-pattern="source surface form|sentence-local Claude repairs away from earlier Claude Code anchors"`
- `npm run build`
- `gpt-5.4-mini` 整篇真实回归：`/Users/rongshen/Downloads/claude-code-sandbox-test.md`
  - 成功写出：`/tmp/mdzh-issue-126-full/output.md`
  - 日志：`/tmp/mdzh-issue-126-full/stderr.log`

## 关联 issue
- 主 feature：#100
- linked bugs：#112, #113, #114, #115, #117, #118, #119, #120, #121, #122, #123, #124, #125, #126

## 后续
- 无
