### PR TITLE
fix: 稳定 anchor normalization 与 smoke 主线 (#171)

### DIFF
--- a/src/anchor-normalization.ts
+++ b/src/anchor-normalization.ts
@@ -1399,7 +1399,25 @@ function normalizeSingleAnchor(
 
 function collapseRepeatedEnglishParentheses(text: string, english: string): string {
   const escapedEnglish = escapeRegExp(english);
-  return text.replace(new RegExp(`（${escapedEnglish}）\\s*（${escapedEnglish}）`, "g"), `（${english}）`);
+  const collapsedExact = text.replace(
+    new RegExp(`（${escapedEnglish}）\\s*（${escapedEnglish}）`, "g"),
+    `（${english}）`
+  );
+  // Also collapse adjacent English-only parens whose contents differ only in
+  // letter case (e.g. `（Prompt injection attacks）（Prompt Injection Attacks）`
+  // produced when heading-recovery appends the source Title Case while anchor
+  // injection has already placed the canonical lowercase form). Keep the
+  // latter paren, since it usually matches the source heading surface shape.
+  return collapsedExact.replace(
+    /（([A-Za-z][A-Za-z0-9 .+/_\-]*)）\s*（([A-Za-z][A-Za-z0-9 .+/_\-]*)）/gu,
+    (match, first, second) => {
+      const a = String(first).trim();
+      const b = String(second).trim();
+      if (!a || !b) return match;
+      if (a.toLowerCase() !== b.toLowerCase()) return match;
+      return `（${b}）`;
+    }
+  );
 }
 
 function normalizeMixedChinesePrimaryParentheses(

--- a/src/anchor-normalization.ts
+++ b/src/anchor-normalization.ts
@@ -2272,9 +2272,45 @@ function replaceExplicitRepairAliasText(
 }
 
 function normalizeExplicitRepairReplacementSpacing(text: string): string {
-  return text
+  const baseNormalized = text
     .replace(/（([^）\n]+)）(?:（\1）)+/gu, "（$1）")
     .replace(/）\s+(?=[\u4e00-\u9fff])/gu, "）");
+  return baseNormalized
+    .split(/\r?\n/)
+    .map((line) => mergeEnglishAnchorWithAdjacentChineseParenInLine(line))
+    .join("\n");
+}
+
+// Collapse `（English anchor）（中文...）` introduced by anchor injection when the
+// original text already carried a Chinese parenthetical (typically the
+// translated explanation of the source `(English ...)` surface). Leaving both
+// parens adjacent reads as a duplicate anchor; merging with a comma preserves
+// both the first-mention anchor and the translated explanation.
+//
+// Only fires on list-item lines (unordered or ordered) because that is where
+// the draft pipeline has produced the duplicate-anchor pattern in smoke runs.
+// Heading content, blockquotes, and plain paragraphs are left untouched so we
+// do not fold legitimately separate trailing parentheticals on heading lines
+// like `## 文件系统权限（Filesystem Permissions）（关键）`, which existing
+// tests expect to stay as two parens.
+function mergeEnglishAnchorWithAdjacentChineseParenInLine(line: string): string {
+  if (!/^\s*(?:[-*+]|\d+[.)])\s+/.test(line)) {
+    return line;
+  }
+  return line.replace(
+    /（([A-Za-z][A-Za-z0-9 .+/_\-]*)）（([^（）\n]+)）/gu,
+    (match, englishInner, chineseInner) => {
+      const english = String(englishInner).trim();
+      const chinese = String(chineseInner).trim();
+      if (!english || !chinese) {
+        return match;
+      }
+      if (!/[\u4e00-\u9fff]/u.test(chinese)) {
+        return match;
+      }
+      return `（${english}，${chinese}）`;
+    }
+  );
 }
 
 function normalizeRepeatedEnglishParenthesesWithLocalHints(text: string): string {

--- a/src/anchor-normalization.ts
+++ b/src/anchor-normalization.ts
@@ -1414,8 +1414,23 @@ function collapseRepeatedEnglishParentheses(text: string, english: string): stri
       const a = String(first).trim();
       const b = String(second).trim();
       if (!a || !b) return match;
-      if (a.toLowerCase() !== b.toLowerCase()) return match;
-      return `（${b}）`;
+      const aLower = a.toLowerCase();
+      const bLower = b.toLowerCase();
+      if (aLower === bLower) {
+        return `（${b}）`;
+      }
+      // Family-variant collapse: when one paren is a whole-word case-insensitive
+      // prefix / suffix of the other (e.g. `（Sandbox）` vs
+      // `（sandbox mode）`), keep the longer surface form and drop the other.
+      if (
+        bLower.startsWith(`${aLower} `) ||
+        bLower.endsWith(` ${aLower}`) ||
+        aLower.startsWith(`${bLower} `) ||
+        aLower.endsWith(` ${bLower}`)
+      ) {
+        return aLower.length >= bLower.length ? `（${a}）` : `（${b}）`;
+      }
+      return match;
     }
   );
 }

--- a/src/anchor-normalization.ts
+++ b/src/anchor-normalization.ts
@@ -1490,10 +1490,46 @@ function normalizeChinesePrimaryInlineExplanation(
   );
 }
 
+function lineAlreadyHasFamilyVariantAnchorParen(text: string, english: string): string | null {
+  const target = english.trim().toLowerCase();
+  if (!target) {
+    return null;
+  }
+  for (const match of text.matchAll(/（([A-Za-z][A-Za-z0-9 .+/_\-]*)）/gu)) {
+    const raw = String(match[1]).trim();
+    if (!raw) {
+      continue;
+    }
+    const lower = raw.toLowerCase();
+    if (lower === target) {
+      return raw;
+    }
+    if (
+      target.startsWith(`${lower} `) ||
+      target.endsWith(` ${lower}`) ||
+      lower.startsWith(`${target} `) ||
+      lower.endsWith(` ${target}`)
+    ) {
+      return raw;
+    }
+  }
+  return null;
+}
+
 function injectAnchorIntoLine(text: string, anchor: PromptAnchor): string {
   const display = resolveAnchorDisplay(anchor);
 
   if (!display.english || display.mode === "english-only") {
+    return text;
+  }
+
+  // Phase 0 anti-runaway guard: if the line already carries an English paren
+  // whose content is a case-insensitive whole-word family variant of this
+  // anchor (same tokens, or one is a whole-word prefix / suffix of the other),
+  // do NOT inject another anchor paren. This is the deterministic
+  // short-circuit that prevents the `（sandbox）（sandbox mode）（Sandbox）`
+  // chain that every downstream collapser is otherwise asked to clean up.
+  if (lineAlreadyHasFamilyVariantAnchorParen(text, display.english)) {
     return text;
   }
 

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -3568,6 +3568,23 @@ function buildStructuredSegmentAuditResult(
   };
 }
 
+// Apply a structured audit to state and sync the filter-truth must_fix back onto
+// the raw `segmentAudit` so the outer repair loop agrees with the state engine on
+// what still needs work. Without this sync the while-loop reads the pre-filter
+// must_fix while the repair dispatch reads the post-filter pendingRepairs, which
+// causes the loop to spin without making progress whenever the filter suppresses
+// an instruction (e.g. anchor already covered) that the auditor still listed.
+function applyStructuredSegmentAuditAndSync(
+  state: TranslationRunState,
+  draftedSegment: DraftedSegmentState,
+  segmentAudit: GateAudit & { segment_index?: number }
+): void {
+  const structured = buildStructuredSegmentAuditResult(state, draftedSegment, segmentAudit);
+  applySegmentAudit(state, structured);
+  segmentAudit.must_fix = [...structured.rawMustFix];
+  segmentAudit.hard_checks = structured.hardChecks;
+}
+
 function buildRepairTasksForSegment(
   state: TranslationRunState,
   segmentId: string,
@@ -6583,10 +6600,7 @@ async function runBundledGateAudit(
           `Chunk ${chunkPromptContext.chunkIndex}/${plan.chunks.length}${chunkLabel}: unknown segment ${segmentAudit.segment_index} in per-segment audit.`
         );
       }
-      applySegmentAudit(
-        context.state,
-        buildStructuredSegmentAuditResult(context.state, draftedSegment, segmentAudit)
-      );
+      applyStructuredSegmentAuditAndSync(context.state, draftedSegment, segmentAudit);
     }
     return bundledAudit;
   }
@@ -6647,10 +6661,7 @@ async function runBundledGateAudit(
             `Chunk ${chunkPromptContext.chunkIndex}/${plan.chunks.length}${chunkLabel}: unknown segment ${segmentAudit.segment_index} in bundled audit.`
           );
         }
-        applySegmentAudit(
-          context.state,
-          buildStructuredSegmentAuditResult(context.state, draftedSegment, segmentAudit)
-        );
+        applyStructuredSegmentAuditAndSync(context.state, draftedSegment, segmentAudit);
       }
       return bundledAudit;
     }
@@ -6690,10 +6701,7 @@ async function runBundledGateAudit(
         `Chunk ${chunkPromptContext.chunkIndex}/${plan.chunks.length}${chunkLabel}: unknown segment ${segmentAudit.segment_index} in bundled audit.`
       );
     }
-    applySegmentAudit(
-      context.state,
-      buildStructuredSegmentAuditResult(context.state, draftedSegment, segmentAudit)
-    );
+    applyStructuredSegmentAuditAndSync(context.state, draftedSegment, segmentAudit);
   }
   return bundledAudit;
 }
@@ -6789,10 +6797,7 @@ async function runFallbackSegmentAudits(
 
     const audit = parseGateAudit(auditResult.text);
     validateStructuralGateChecks(audit);
-    applySegmentAudit(
-      context.state,
-      buildStructuredSegmentAuditResult(context.state, draftedSegment, audit)
-    );
+    applyStructuredSegmentAuditAndSync(context.state, draftedSegment, audit);
     segments.push({
       segment_index: draftedSegment.segment.index + 1,
       ...audit

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -4211,6 +4211,13 @@ function suppressCoveredAnchorMustFix(
   }
 
   const remainingMustFix = audit.must_fix.filter((instruction) => {
+    // materializeFailedHardCheckProblems injects structural-check failures as
+    // must_fix with a stable sentinel prefix ("硬性检查 "). Those are not
+    // anchor-related even if the underlying problem text happens to mention
+    // an anchor surface — never let anchor-coverage heuristics suppress them.
+    if (/^硬性检查\s/u.test(instruction.trim())) {
+      return true;
+    }
     const anchors = [...slice.requiredAnchors, ...slice.repeatAnchors, ...slice.establishedAnchors];
     const explicitLocationText = extractExplicitRepairLocationText(instruction);
     if (isAnalysisPlanTargetAlreadySatisfied(slice, draftedSegment, instruction, explicitLocationText)) {

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -3634,7 +3634,22 @@ function collapseRunawayEnglishAnchorChain(text: string): string {
   // Normalize accidental 4-star bold delimiters `****` to `**`; keep paired so
   // we do not corrupt balanced bold sequences elsewhere in the line.
   const collapseDoubleBold = (input: string): string => input.replace(/\*{4,}/g, "**");
-  return collapseDoubleBold(collapseChain(text));
+  // If a line has an odd number of `**` markers, anchor injection likely
+  // inserted `（anchor）` after a closed bold span and appended a stray `**`
+  // tail (e.g. `**拒绝**。（Deny）**。`). Trim the dangling tail so the
+  // protected_span_integrity audit no longer sees an unpaired `**`.
+  const stripDanglingBoldTail = (input: string): string =>
+    input
+      .split(/\r?\n/)
+      .map((line) => {
+        const boldCount = (line.match(/\*\*/g) ?? []).length;
+        if (boldCount === 0 || boldCount % 2 === 0) {
+          return line;
+        }
+        return line.replace(/\*\*([\p{P}\p{S}\s]*)$/u, "$1");
+      })
+      .join("\n");
+  return stripDanglingBoldTail(collapseDoubleBold(collapseChain(text)));
 }
 
 function dedupDraftDuplicateTailBlocks(source: string, draft: string): string {

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -5957,6 +5957,24 @@ function getDraftContractViolation(source: string, text: string): string | null 
     return "draft returned meta/audit text";
   }
 
+  // Catch the "lazy LLM" pattern where a list item is replaced by ellipsis
+  // ("- ……" or "- ...") but the source list item is real content. The audit
+  // catches this too but repairing from a missing item is harder than rejecting
+  // it at the draft contract.
+  const ellipsisLineInBody = trimmed.split(/\r?\n/).some((line) => {
+    const stripped = line.replace(/^\s*(?:[-*+]|\d+[.)])\s+/, "").trim();
+    return /^(?:…+|\.{3,})$/.test(stripped);
+  });
+  if (ellipsisLineInBody) {
+    const sourceHasEllipsisItem = source.split(/\r?\n/).some((line) => {
+      const stripped = line.replace(/^\s*(?:[-*+]|\d+[.)])\s+/, "").trim();
+      return /^(?:…+|\.{3,})$/.test(stripped);
+    });
+    if (!sourceHasEllipsisItem) {
+      return "draft replaced a list item with ellipsis instead of translating it";
+    }
+  }
+
   if (looksLikeStructuredOutputDebris(source, trimmed)) {
     return "draft returned structured-output debris instead of translated content";
   }

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -3631,6 +3631,33 @@ function collapseRunawayEnglishAnchorChain(text: string): string {
         return kept.map((paren) => `（${paren}）`).join("");
       }
     );
+  // Separately collapse two adjacent parens that are case-only duplicates or
+  // case-insensitive whole-word family variants (e.g. `（Sandbox）`, `（sandbox
+  // mode）`). Runs at the post-normalizer stage so lines where anchor injection
+  // short-circuited earlier still get the cleanup.
+  const collapsePairs = (input: string): string =>
+    input.replace(
+      /（([A-Za-z][A-Za-z0-9 .+/_\-]*)）\s*（([A-Za-z][A-Za-z0-9 .+/_\-]*)）/gu,
+      (match, first, second) => {
+        const a = String(first).trim();
+        const b = String(second).trim();
+        if (!a || !b) return match;
+        const aLower = a.toLowerCase();
+        const bLower = b.toLowerCase();
+        if (aLower === bLower) {
+          return `（${b}）`;
+        }
+        if (
+          bLower.startsWith(`${aLower} `) ||
+          bLower.endsWith(` ${aLower}`) ||
+          aLower.startsWith(`${bLower} `) ||
+          aLower.endsWith(` ${bLower}`)
+        ) {
+          return aLower.length >= bLower.length ? `（${a}）` : `（${b}）`;
+        }
+        return match;
+      }
+    );
   // Normalize accidental 4-star bold delimiters `****` to `**`; keep paired so
   // we do not corrupt balanced bold sequences elsewhere in the line.
   const collapseDoubleBold = (input: string): string => input.replace(/\*{4,}/g, "**");
@@ -3649,7 +3676,7 @@ function collapseRunawayEnglishAnchorChain(text: string): string {
         return line.replace(/\*\*([\p{P}\p{S}\s]*)$/u, "$1");
       })
       .join("\n");
-  return stripDanglingBoldTail(collapseDoubleBold(collapseChain(text)));
+  return stripDanglingBoldTail(collapseDoubleBold(collapsePairs(collapseChain(text))));
 }
 
 function dedupDraftDuplicateTailBlocks(source: string, draft: string): string {

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -3599,6 +3599,44 @@ function materializeFailedHardCheckProblems(audit: GateAudit): GateAudit {
 // near-duplicate of the preceding window of the same length. When both hold,
 // trim the tail. Block similarity is measured as normalized-char overlap to
 // accommodate LLM paraphrase.
+// Collapse runaway English-anchor parenthesis chains like
+// `（sandbox mode）（Sandbox）（sandbox mode）**（sandbox mode）**` that the
+// anchor injection chain can produce when several passes each append a
+// canonical display without detecting the one inserted by an earlier layer.
+// Also collapses `****` (double bold delimiter) that the same sequence can
+// leave behind. Only fires when 3 or more adjacent parens share a case-
+// insensitive English form, so cases with a single anchor or two legitimately
+// distinct English tokens are left untouched.
+function collapseRunawayEnglishAnchorChain(text: string): string {
+  const collapseChain = (input: string): string =>
+    input.replace(
+      /(?:（([A-Za-z][A-Za-z0-9 .+/_\-]*)）(?:\s*\*{0,4}\s*)){3,}/gu,
+      (match) => {
+        const parens = [...match.matchAll(/（([A-Za-z][A-Za-z0-9 .+/_\-]*)）/gu)].map((m) =>
+          String(m[1]).trim()
+        );
+        if (parens.length < 3) {
+          return match;
+        }
+        const seen = new Set<string>();
+        const kept: string[] = [];
+        for (const paren of parens) {
+          const key = paren.toLowerCase();
+          if (seen.has(key)) {
+            continue;
+          }
+          seen.add(key);
+          kept.push(paren);
+        }
+        return kept.map((paren) => `（${paren}）`).join("");
+      }
+    );
+  // Normalize accidental 4-star bold delimiters `****` to `**`; keep paired so
+  // we do not corrupt balanced bold sequences elsewhere in the line.
+  const collapseDoubleBold = (input: string): string => input.replace(/\*{4,}/g, "**");
+  return collapseDoubleBold(collapseChain(text));
+}
+
 function dedupDraftDuplicateTailBlocks(source: string, draft: string): string {
   if (!draft || !source) {
     return draft;
@@ -5633,8 +5671,10 @@ async function translateProtectedSegment(
     protectedSource,
     restoredCodeLikeDraftText
   );
-  const normalizedDraftSurfaceText = normalizeMalformedInlineEnglishEmphasis(
-    normalizeMarkdownLinkLabelWhitespace(restoredExampleTokenDraftText)
+  const normalizedDraftSurfaceText = collapseRunawayEnglishAnchorChain(
+    normalizeMalformedInlineEnglishEmphasis(
+      normalizeMarkdownLinkLabelWhitespace(restoredExampleTokenDraftText)
+    )
   );
   const canonicalProtectedBody = reprotectMarkdownSpans(normalizedDraftSurfaceText, combinedSpans);
   const restoredBody = restoreMarkdownSpans(canonicalProtectedBody, combinedSpans);
@@ -6268,8 +6308,10 @@ async function repairDraftedSegment(
       draftedSegment.protectedSource,
       restoredCodeLikeRepairText
     );
-    const normalizedRepairSurfaceText = normalizeMalformedInlineEnglishEmphasis(
-      normalizeMarkdownLinkLabelWhitespace(restoredExampleTokenRepairText)
+    const normalizedRepairSurfaceText = collapseRunawayEnglishAnchorChain(
+      normalizeMalformedInlineEnglishEmphasis(
+        normalizeMarkdownLinkLabelWhitespace(restoredExampleTokenRepairText)
+      )
     );
     draftedSegment.protectedBody = reprotectMarkdownSpans(
       normalizedRepairSurfaceText,

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -5848,6 +5848,19 @@ function getDraftContractViolation(source: string, text: string): string | null 
     return source.trim() ? "draft returned empty content" : null;
   }
 
+  const trimmedSource = source.trim();
+  if (trimmed === trimmedSource) {
+    const strippedSource = trimmedSource
+      .replace(/```[\s\S]*?```/g, "")
+      .replace(/`[^`]*`/g, "")
+      .replace(/\bhttps?:\/\/\S+/gi, "")
+      .replace(/[\p{P}\p{S}\s]/gu, "");
+    const englishLetters = strippedSource.match(/[A-Za-z]/g);
+    if (englishLetters && englishLetters.length >= 15 && !/[\u4e00-\u9fff]/u.test(trimmed)) {
+      return "draft echoed the source verbatim instead of translating";
+    }
+  }
+
   if (
     /file:\/\//i.test(trimmed) ||
     /\[[^\]]+\.md\]\(file:\/\//i.test(trimmed) ||

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -3551,6 +3551,40 @@ function extractHeadingEnglishCoreTerm(
 // against the source, so a segment that came back untranslated can pass every
 // structural check. Inject a synthetic must_fix (with a matching structured
 // target) so the repair lane is forced to retranslate it.
+// Promote failed hard_check problems into must_fix entries. The audit LLM
+// sometimes reports a structural / style failure via hard_checks (e.g.
+// chinese_punctuation.pass=false with a clear problem) but leaves must_fix
+// empty. Without a must_fix entry the repair loop treats the chunk as "no work
+// to do", exits early, and the failure is never repaired even though
+// isBundledHardPass remains false. Mirror each failed hard_check problem into
+// must_fix so the repair lane has an actionable instruction.
+function materializeFailedHardCheckProblems(audit: GateAudit): GateAudit {
+  const extras: string[] = [];
+  const existing = new Set((audit.must_fix ?? []).map((entry) => entry.trim()));
+  for (const [checkName, check] of Object.entries(audit.hard_checks ?? {})) {
+    if (check?.pass !== false) {
+      continue;
+    }
+    const problem = check.problem?.trim();
+    if (!problem) {
+      continue;
+    }
+    const mustFixEntry = `硬性检查 ${checkName} 未通过：${problem}`;
+    if (existing.has(mustFixEntry)) {
+      continue;
+    }
+    existing.add(mustFixEntry);
+    extras.push(mustFixEntry);
+  }
+  if (extras.length === 0) {
+    return audit;
+  }
+  return {
+    ...audit,
+    must_fix: [...(audit.must_fix ?? []), ...extras]
+  };
+}
+
 function injectUntranslatedSegmentMustFix(
   draftedSegment: DraftedSegmentState,
   audit: GateAudit
@@ -3593,7 +3627,9 @@ function buildStructuredSegmentAuditResult(
 ): StateSegmentAuditResult {
   const chunkId = draftedSegment.segmentId.split("-segment-")[0] ?? `chunk-${draftedSegment.segment.index + 1}`;
   const slice = buildSegmentTaskSlice(state, chunkId, draftedSegment.segmentId);
-  const guardedAudit = injectUntranslatedSegmentMustFix(draftedSegment, audit);
+  const guardedAudit = materializeFailedHardCheckProblems(
+    injectUntranslatedSegmentMustFix(draftedSegment, audit)
+  );
   const expandedAudit = expandMissingAnchorMustFixes(guardedAudit);
   const filteredAudit = suppressCoveredAnchorMustFix(state, draftedSegment, slice, expandedAudit);
   const repairTasks = buildRepairTasksForSegment(state, draftedSegment.segmentId, {

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -3585,30 +3585,43 @@ function materializeFailedHardCheckProblems(audit: GateAudit): GateAudit {
   };
 }
 
-function injectUntranslatedSegmentMustFix(
-  draftedSegment: DraftedSegmentState,
-  audit: GateAudit
-): GateAudit {
+// Predicate for "this segment's translated body is just an echo of the English
+// source". Used by injectUntranslatedSegmentMustFix to add a repair
+// instruction during audit. Central rules: segment must be translatable (not
+// a fixed non-translatable block); source trimmed equals body trimmed; after
+// stripping fenced/inline code and URLs the source has at least 15 English
+// letters; the body contains zero CJK characters.
+function isSegmentStillEchoingSource(draftedSegment: DraftedSegmentState): boolean {
+  if (draftedSegment.segment.kind !== "translatable") {
+    return false;
+  }
   const source = draftedSegment.segment.source ?? "";
   const body = draftedSegment.restoredBody ?? "";
-  if (!source.trim() || source.trim() !== body.trim()) {
-    return audit;
+  const trimmedSource = source.trim();
+  const trimmedBody = body.trim();
+  if (!trimmedSource || trimmedSource !== trimmedBody) {
+    return false;
   }
-  // Strip fenced/inline code + link destinations so we don't trip on segments
-  // that are legitimately code-only or URL-only.
-  const strippedSource = source
+  const strippedSource = trimmedSource
     .replace(/```[\s\S]*?```/g, "")
     .replace(/`[^`]*`/g, "")
     .replace(/\bhttps?:\/\/\S+/gi, "")
     .replace(/[\p{P}\p{S}\s]/gu, "");
   const englishLetters = strippedSource.match(/[A-Za-z]/g);
   if (!englishLetters || englishLetters.length < 15) {
-    return audit;
+    return false;
   }
-  // If the body contains any CJK ideograph, assume the translator at least
-  // partially rendered Chinese and skip the guard (the existing anchor checks
-  // will catch finer issues).
-  if (/[\u4e00-\u9fff]/u.test(body)) {
+  if (/[\u4e00-\u9fff]/u.test(trimmedBody)) {
+    return false;
+  }
+  return true;
+}
+
+function injectUntranslatedSegmentMustFix(
+  draftedSegment: DraftedSegmentState,
+  audit: GateAudit
+): GateAudit {
+  if (!isSegmentStillEchoingSource(draftedSegment)) {
     return audit;
   }
 

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -3546,6 +3546,46 @@ function extractHeadingEnglishCoreTerm(
   return null;
 }
 
+// Detect the "draft echoed the source verbatim" failure mode. The bundled /
+// per-segment audit LLMs have no hard_check that actually compares the body
+// against the source, so a segment that came back untranslated can pass every
+// structural check. Inject a synthetic must_fix (with a matching structured
+// target) so the repair lane is forced to retranslate it.
+function injectUntranslatedSegmentMustFix(
+  draftedSegment: DraftedSegmentState,
+  audit: GateAudit
+): GateAudit {
+  const source = draftedSegment.segment.source ?? "";
+  const body = draftedSegment.restoredBody ?? "";
+  if (!source.trim() || source.trim() !== body.trim()) {
+    return audit;
+  }
+  // Strip fenced/inline code + link destinations so we don't trip on segments
+  // that are legitimately code-only or URL-only.
+  const strippedSource = source
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/`[^`]*`/g, "")
+    .replace(/\bhttps?:\/\/\S+/gi, "")
+    .replace(/[\p{P}\p{S}\s]/gu, "");
+  const englishLetters = strippedSource.match(/[A-Za-z]/g);
+  if (!englishLetters || englishLetters.length < 15) {
+    return audit;
+  }
+  // If the body contains any CJK ideograph, assume the translator at least
+  // partially rendered Chinese and skip the guard (the existing anchor checks
+  // will catch finer issues).
+  if (/[\u4e00-\u9fff]/u.test(body)) {
+    return audit;
+  }
+
+  const instruction =
+    "当前分段译文与原文完全一致，未完成翻译。请将其翻译为中文正文，保留 Markdown 结构与受保护片段。";
+  return {
+    ...audit,
+    must_fix: [instruction, ...(audit.must_fix ?? [])]
+  };
+}
+
 function buildStructuredSegmentAuditResult(
   state: TranslationRunState,
   draftedSegment: DraftedSegmentState,
@@ -3553,7 +3593,8 @@ function buildStructuredSegmentAuditResult(
 ): StateSegmentAuditResult {
   const chunkId = draftedSegment.segmentId.split("-segment-")[0] ?? `chunk-${draftedSegment.segment.index + 1}`;
   const slice = buildSegmentTaskSlice(state, chunkId, draftedSegment.segmentId);
-  const expandedAudit = expandMissingAnchorMustFixes(audit);
+  const guardedAudit = injectUntranslatedSegmentMustFix(draftedSegment, audit);
+  const expandedAudit = expandMissingAnchorMustFixes(guardedAudit);
   const filteredAudit = suppressCoveredAnchorMustFix(state, draftedSegment, slice, expandedAudit);
   const repairTasks = buildRepairTasksForSegment(state, draftedSegment.segmentId, {
     segment: { source: draftedSegment.segment.source },

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -3591,6 +3591,80 @@ function materializeFailedHardCheckProblems(audit: GateAudit): GateAudit {
 // a fixed non-translatable block); source trimmed equals body trimmed; after
 // stripping fenced/inline code and URLs the source has at least 15 English
 // letters; the body contains zero CJK characters.
+// When the draft / repair LLM visibly "retries" by appending a re-run of
+// earlier blocks, the chunk ends up with its bullets or paragraphs duplicated
+// back-to-back. Detect this pattern deterministically so the downstream
+// normalizers see a cleanly-sized body: require (a) draft block count to
+// exceed source block count, and (b) the longest possible tail to be a
+// near-duplicate of the preceding window of the same length. When both hold,
+// trim the tail. Block similarity is measured as normalized-char overlap to
+// accommodate LLM paraphrase.
+function dedupDraftDuplicateTailBlocks(source: string, draft: string): string {
+  if (!draft || !source) {
+    return draft;
+  }
+  const splitBlocks = (text: string): string[] =>
+    text
+      .split(/\n{2,}/)
+      .map((block) => block.replace(/\s+$/, ""))
+      .filter((block) => block.trim().length > 0);
+  const sourceBlocks = splitBlocks(source);
+  const draftBlocks = splitBlocks(draft);
+  if (draftBlocks.length <= sourceBlocks.length) {
+    return draft;
+  }
+  const maxTrim = draftBlocks.length - sourceBlocks.length;
+  for (let tailLen = maxTrim; tailLen >= 1; tailLen -= 1) {
+    const tailStart = draftBlocks.length - tailLen;
+    if (tailStart < tailLen) {
+      continue;
+    }
+    const earlierStart = tailStart - tailLen;
+    let allSimilar = true;
+    for (let k = 0; k < tailLen; k += 1) {
+      if (!draftBlocksLookLikeDuplicate(draftBlocks[earlierStart + k] ?? "", draftBlocks[tailStart + k] ?? "")) {
+        allSimilar = false;
+        break;
+      }
+    }
+    if (allSimilar) {
+      return draftBlocks.slice(0, tailStart).join("\n\n");
+    }
+  }
+  return draft;
+}
+
+function draftBlocksLookLikeDuplicate(a: string, b: string): boolean {
+  const normalize = (s: string) =>
+    s
+      .replace(/\s+/gu, "")
+      .replace(/[（(][^）)]{0,60}[）)]/gu, "")
+      .replace(/[\p{P}\p{S}]/gu, "");
+  const na = normalize(a);
+  const nb = normalize(b);
+  if (!na || !nb) {
+    return false;
+  }
+  if (na === nb) {
+    return true;
+  }
+  const minLen = Math.min(na.length, nb.length);
+  const maxLen = Math.max(na.length, nb.length);
+  if (minLen < 12 || minLen / maxLen < 0.6) {
+    return false;
+  }
+  const sample = na.length <= nb.length ? na : nb;
+  const other = na.length <= nb.length ? nb : na;
+  let hits = 0;
+  for (let i = 0; i + 3 <= sample.length; i += 3) {
+    if (other.includes(sample.slice(i, i + 3))) {
+      hits += 1;
+    }
+  }
+  const ngrams = Math.max(1, Math.floor(sample.length / 3));
+  return hits / ngrams >= 0.55;
+}
+
 function isSegmentStillEchoingSource(draftedSegment: DraftedSegmentState): boolean {
   if (draftedSegment.segment.kind !== "translatable") {
     return false;
@@ -5504,8 +5578,9 @@ async function translateProtectedSegment(
     );
   }
   threadId = draftResult.threadId;
+  const dedupedDraftText = dedupDraftDuplicateTailBlocks(protectedSource, draftResult.text);
   const normalizedDraftText = normalizeSegmentAnchorText(
-    stripAddedInlineCodeFromPlainPaths(protectedSource, draftResult.text),
+    stripAddedInlineCodeFromPlainPaths(protectedSource, dedupedDraftText),
     chunkPromptContext.stateSlice
   );
   const injectedDraftText = injectPlannedAnchorText(
@@ -6112,8 +6187,12 @@ async function repairDraftedSegment(
     if (repairResult.threadId) {
       draftedSegment.threadId = repairResult.threadId;
     }
+    const dedupedRepairText = dedupDraftDuplicateTailBlocks(
+      draftedSegment.protectedSource,
+      repairResult.text
+    );
     const normalizedRepairText = normalizeSegmentAnchorText(
-      stripAddedInlineCodeFromPlainPaths(draftedSegment.protectedSource, repairResult.text),
+      stripAddedInlineCodeFromPlainPaths(draftedSegment.protectedSource, dedupedRepairText),
       buildSegmentTaskSlice(context.state, context.chunkId, draftedSegment.segmentId)
     );
     const injectedRepairText = injectPlannedAnchorText(

--- a/src/translation-state.ts
+++ b/src/translation-state.ts
@@ -1223,14 +1223,6 @@ function reconcileSegmentSemanticPlans(
   state: TranslationRunState,
   segment: SegmentState
 ): { headingPlans: HeadingPlanState[]; blockPlans: BlockPlanState[]; emphasisPlans: EmphasisPlanState[] } {
-  if (segment.headingPlans.length === 0) {
-    return {
-      headingPlans: segment.headingPlans.map((plan) => ({ ...plan })),
-      blockPlans: segment.blockPlans.map((plan) => ({ ...plan })),
-      emphasisPlans: segment.emphasisPlans.map((plan) => ({ ...plan }))
-    };
-  }
-
   const headingPlans = segment.headingPlans.map((plan) => ({ ...plan }));
   const blockPlans = segment.blockPlans.map((plan) => ({ ...plan }));
   const emphasisPlans = segment.emphasisPlans.map((plan) => ({ ...plan }));

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -2457,7 +2457,12 @@ test("translateMarkdownArticle skips bundled audit for large multi-segment chunk
         return createExecResult(current);
       }
       const sourceSection = extractPromptSection(prompt, "【英文原文】");
-      return createExecResult(sourceSection ?? "");
+      // Return Chinese placeholder content rather than echoing the English
+      // source so the draft contract and the untranslated-segment guard treat
+      // the mock as a real translation. This test exists to verify that
+      // bundled audit is skipped for large multi-segment chunks, not to
+      // exercise the echoed-source repair path.
+      return createExecResult(sourceSection ? "中文占位译文" : "");
     }
   };
 


### PR DESCRIPTION
## 目的

收口 #171 这轮 smoke 失败排障。把 16 条不同类别的架构 + hotfix 修复合并成一个阶段性交付，不追求 full smoke 100% 通过（受限于 LLM 随机性），但把所有可以确定性修复的路径修好。

## 范围

16 commits，按主题聚合：

**架构自锁类（4）**
- \`d7787ae\` filter/audit sync，解死锁
- \`a4cb510\` emphasis/block plan 无 heading 时也 reconcile
- \`db8f314\` 硬检 problem 翻写为 must_fix
- \`1940e65\` untranslated-segment guard 只对 translatable 分段触发

**Draft / repair contract 补强（3）**
- \`808258c\` echoed-source 注入 must_fix
- \`c6736d8\` repair 输出 echo 原文视作 contract 违反
- \`1a98363\` 列表项被替换为 \`……\` 视作 contract 违反

**Anchor normalization 确定性防线（6）**
- \`787f8e8\` 列表项 \`（英文）（中文解释）\` 合并
- \`bace02f\` 大小写重复英文括注合并
- \`b7081c8\` draft / repair 尾段重复去重
- \`72a97e8\` runaway 英文括注链 + \`****\` 回收
- \`9925a34\` family-variant 括注合并
- \`8760867\` paren-pair 合并提前到 post-normalizer
- \`f80c835\` 行内奇数 \`**\` 尾部残尾裁剪
- \`f96321f\` materialize 后的 must_fix 不被 anchor-coverage 过滤吞

**最终 idempotency（1）**
- \`4cd5f37\` P0 short-circuit：injectAnchorIntoLine 入口加 family-variant 已有时直接 skip，作为后续 #2 OwnerMap 重构的雏形

## 验证

- \`npm test\`：16 次迭代全程保持 baseline 失败 125 → 124，零新增回归；修好一条 \`translation state reconciles emphasis and block targets to the canonical bilingual anchor display\`。
- \`npm run smoke:once -- --fixture short\`：hard gate 可通过，独立质检问题从 6 条降到 2 条。
- \`npm run smoke:once -- --fixture full\`：从 chunk 1 早期崩盘推进到 chunk 2–3 稳定通过、偶发 chunk 4 / chunk 8。

## 后续

- 本 PR 合入后，#2（OwnerMap 执行层）PR 会自动 rebase 到干净 main，可接续合入。
- 剩余 LLM 随机性问题归并到 #3（analysis 层嵌套括注策略）与后续 P2（draft lane 迁 JSON blocks）issue。

🤖 Generated with [Claude Code](https://claude.com/claude-code)