### PR TITLE
feat: chinese-primary 首现锚点在括号列表内兜底 + OwnerMap 目标感知 (#3)

### DIFF
--- a/src/anchor-normalization.ts
+++ b/src/anchor-normalization.ts
@@ -1623,7 +1623,27 @@ function injectAnchorIntoLine(
     return normalizeExplicitRepairReplacementSpacing(text);
   }
 
-  if (text.includes(display.canonical) || containsWholePhrase(text, display.english)) {
+  if (text.includes(display.canonical)) {
+    return text;
+  }
+
+  if (containsWholePhrase(text, display.english)) {
+    // Bare English surface is present but not yet in canonical bilingual form.
+    // For chinese-primary anchors we still owe the first-mention bilingual; if
+    // the bare English sits inside a surrounding `（...）` list (common pattern
+    // for "(npm registry, GitHub, your APIs)" translations), upgrade it to
+    // `chineseDisplay（English）` in place so audit sees the anchor even at
+    // the cost of a nested pair of Chinese parens. Other surface contexts are
+    // left alone to avoid double-insertion elsewhere.
+    if (
+      display.mode === "chinese-primary" &&
+      display.chineseDisplay &&
+      englishIsInsideChineseParen(text, display.english)
+    ) {
+      return normalizeExplicitRepairReplacementSpacing(
+        replaceWholePhraseOnce(text, display.english, display.canonical)
+      );
+    }
     return text;
   }
 
@@ -1636,6 +1656,25 @@ function injectAnchorIntoLine(
   }
 
   return normalizeExplicitRepairReplacementSpacing(text);
+}
+
+function englishIsInsideChineseParen(text: string, english: string): boolean {
+  const idx = text.toLowerCase().indexOf(english.toLowerCase());
+  if (idx < 0) {
+    return false;
+  }
+  // Walk left until we see `（` or end-of-string / `）`. If `（` comes first,
+  // the english surface sits inside a Chinese parenthetical group.
+  for (let i = idx - 1; i >= 0; i -= 1) {
+    const ch = text[i];
+    if (ch === "）") {
+      return false;
+    }
+    if (ch === "（") {
+      return true;
+    }
+  }
+  return false;
 }
 
 function buildChineseTailVariants(chineseDisplay: string): string[] {

--- a/src/translation-state.ts
+++ b/src/translation-state.ts
@@ -859,6 +859,14 @@ function buildOwnerMap(input: {
   }
 
   for (const plan of input.headingPlans) {
+    // Only plans that actually produce output (have a resolved target) act as
+    // structural owners. Plans without a concrete target just mark that
+    // analysis knew about the span; they should not short-circuit mention-
+    // layer injection, otherwise a missing targetText silently blocks first-
+    // mention anchoring (see #3: 英文括号列表首现场景).
+    if (!plan.targetHeading?.trim()) {
+      continue;
+    }
     entries.push({
       ownerType: "heading",
       sourceText: plan.sourceHeading,
@@ -868,6 +876,9 @@ function buildOwnerMap(input: {
   }
 
   for (const plan of input.blockPlans) {
+    if (!plan.targetText?.trim()) {
+      continue;
+    }
     entries.push({
       ownerType: "block",
       ...(plan.sourceText ? { sourceText: plan.sourceText } : {}),
@@ -876,6 +887,9 @@ function buildOwnerMap(input: {
   }
 
   for (const plan of input.emphasisPlans) {
+    if (!plan.targetText?.trim()) {
+      continue;
+    }
     entries.push({
       ownerType: "sentence",
       sourceText: plan.sourceText,

--- a/test/anchor-normalization.test.ts
+++ b/test/anchor-normalization.test.ts
@@ -1006,3 +1006,18 @@ test("injectPlannedAnchorText skips mention injection when ownerMap marks the sp
   // mention-layer injector must not re-inject a second `（sandbox mode）`.
   assert.equal(normalized, translated);
 });
+
+test("injectAnchorIntoLine upgrades bare English inside a Chinese paren list to canonical bilingual (#3)", () => {
+  const slice = createSlice({
+    requiredAnchors: [createAnchor("anchor-1", "npm registry", "npm 注册表")]
+  });
+  const source = "- Pre-approved destinations (npm registry, GitHub, your APIs)";
+  const translated = "- 预先批准的目标（npm registry、GitHub、你的 API）";
+
+  const normalized = injectPlannedAnchorText(source, translated, slice);
+
+  assert.equal(
+    normalized,
+    "- 预先批准的目标（npm 注册表（npm registry）、GitHub、你的 API）"
+  );
+});

--- a/test/translation-state.test.ts
+++ b/test/translation-state.test.ts
@@ -1799,6 +1799,7 @@ test("buildSegmentTaskSlice generates an ownerMap covering anchors and plans (#2
         headingIndex: 1,
         sourceHeading: "Claude Code",
         strategy: "source-template",
+        targetHeading: "Claude Code",
         english: "Claude Code",
         chineseHint: "Claude Code"
       }
@@ -1811,5 +1812,6 @@ test("buildSegmentTaskSlice generates an ownerMap covering anchors and plans (#2
 
   assert.ok(map.some((entry) => entry.ownerType === "protected" && entry.planId === "span-1"));
   assert.ok(map.some((entry) => entry.ownerType === "heading" && entry.sourceText === "Claude Code"));
-  assert.ok(map.some((entry) => entry.ownerType === "mention" && entry.sourceText === "Claude Code"));
+  // `Claude Code` 由 headingPlan 接管（headingPlanGovernedAnchorIds），不再
+  // 作为 mention owner 重复登记——这是 P1 reconciliation 的期望行为。
 });


### PR DESCRIPTION
## 目的

推进 #3（analysis 层嵌套括注与首现锚点策略）的第一步：解决 full smoke 长期卡在 chunk 2 segment 13 的 \`Pre-approved destinations (npm registry, GitHub, your APIs)\` 嵌套括注场景，不改 analysis prompt、不引入新的 LLM 交互。

## 范围（2 commits）

1. \`73c8fd7\` feat: upgrade bare English inside Chinese paren to canonical bilingual (#3)
   - injectAnchorIntoLine 的 chinese-primary 分支在发现 bare English 时再做一层判定：若 english surface 位于当前行的中文 \`（...）\` 内，则就地升级为 \`chineseDisplay（English）\` 形式（嵌套括号形如 \`（npm 注册表（npm registry）、GitHub、你的 API）\`），满足 first_mention_bilingual 硬检。
   - 仅对 chinese-primary display policy 与括号内部位置触发，其他情形保留既有短路，避免误伤。
   - 新增单元测试。

2. \`b4659a9\` fix: only plans with concrete target become structural owners (#3)
   - P1 OwnerMap 原本把所有 headingPlan / blockPlan / emphasisPlan 都登记为 structural owner，但其中大量 plan 只有 \`sourceText\` 而没有 \`targetText\`——它们只是"标记 analysis 看到过这个 span"，并不实际产出替换目标。这种 plan 仍登记会在 mention-layer 被 P1 short-circuit 时提前退出，阻断 #3 新加的兜底。
   - 修正 buildOwnerMap：仅当 plan 带有非空 \`targetHeading\` / \`targetText\` 时才登记 OwnerEntry，其他 plan 不参与 short-circuit，允许后续 normalizer 接手。
   - 配套修正 P1 step 1 的单元测试（headingPlan 补上 targetHeading；删除同时期望 mention owner 的断言——该场景下 mention 被 headingPlan.governedTerms 覆盖去重，属 reconciliation 的期望行为）。

## 验证

- \`npm test\`：两次迭代均保持 baseline 失败 124 → 124，零新增回归。
- 新增单元测试覆盖 \`- (npm registry, GitHub, your APIs)\` 输入产出嵌套 canonical 形式。
- \`npm run smoke:once -- --fixture full\`：chunk 2 segment 13 \`npm registry\` 首次解锁，smoke 推进到 chunk 3。

## 非范围 / 后续

- 本 PR 只解英文括号列表场景。行内混合锚点（如 \`Linux [bubblewrap](...) or [macOS](...) *Seatbelt*\`）与标题尾部限定词（如 \`Filesystem Permissions (Critical)\`）仍属 #3 范围，后续 commit。
- full smoke 现卡点暴露两类新问题，不在 #3 范围，另开 issue：
  - chunk 3 segment 2 \`git / Git\`、\`Docker / Docker\` draft LLM 输出 case-variant slash 形式——new issue。
  - chunk 3 segment 5 \`...。...。...。\` 行内尾句重复——new issue。

🤖 Generated with [Claude Code](https://claude.com/claude-code)