### PR TITLE
fix: 合并 Chinese 括号内的大小写变体 slash 双写 (#8)

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -3676,7 +3676,31 @@ function collapseRunawayEnglishAnchorChain(text: string): string {
         return line.replace(/\*\*([\p{P}\p{S}\s]*)$/u, "$1");
       })
       .join("\n");
-  return stripDanglingBoldTail(collapseDoubleBold(collapsePairs(collapseChain(text))));
+  return stripDanglingBoldTail(
+    collapseDoubleBold(collapsePairs(collapseChain(collapseCaseVariantSlashInParens(text))))
+  );
+}
+
+// Issue #8: when draft LLM emits `（git / Git、...）` or `（Docker / Docker）`,
+// collapse the `A / B` pair to a single token when A and B differ only in
+// letter case. Scoped to the content inside Chinese parens so normal
+// `and / or`-style text outside parens is not touched.
+function collapseCaseVariantSlashInParens(text: string): string {
+  return text.replace(/（([^（）\n]+)）/gu, (match, innerRaw) => {
+    const inner = String(innerRaw);
+    const collapsed = inner.replace(
+      /([A-Za-z][A-Za-z0-9.+_-]*)\s*\/\s*([A-Za-z][A-Za-z0-9.+_-]*)/g,
+      (pairMatch, left, right) => {
+        const a = String(left);
+        const b = String(right);
+        if (a.toLowerCase() !== b.toLowerCase()) {
+          return pairMatch;
+        }
+        return a.length <= b.length ? a : b;
+      }
+    );
+    return collapsed === inner ? match : `（${collapsed}）`;
+  });
 }
 
 function dedupDraftDuplicateTailBlocks(source: string, draft: string): string {


### PR DESCRIPTION
## 目的

解 #8：draft LLM 偶发把英文单词锚点写成 \`word / Word\` 形式（case-variant slash 双写），audit 判为"英文重复括注"。

## 范围（1 commit）

\`c0c8c16\` fix: collapse case-variant slash pairs inside Chinese parens (#8)

- 新增 \`collapseCaseVariantSlashInParens\` 作为 draft / repair 正文链 \`collapseRunawayEnglishAnchorChain\` 的首个清理步骤。
- 仅扫描中文全角括号 \`（...）\` 内部。
- 仅合并 ASCII 字母起始、大小写不敏感相等的两个 token（例：\`git / Git\`、\`Docker / Docker\`）。
- 括号外的 \`and / or\` 等不动；不同英文 token 之间的 \`/\` 保持。

## 验证

- \`npm test\`：baseline failing 124 → 124，零新增回归。
- 手工 repro：\`（git / Git、npm）\` → \`（git、npm）\`，\`（Docker / Docker）\` → \`（Docker）\`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)