### PR TITLE
fix: 拦截 prompt 指令短语泄漏到译文正文

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -6129,7 +6129,7 @@ function getDraftContractViolation(source: string, text: string): string | null 
   if (
     /file:\/\//i.test(trimmed) ||
     /\[[^\]]+\.md\]\(file:\/\//i.test(trimmed) ||
-    /(源文件|对应段落|当前块|硬性项|无需修正|没有发现需要|已核对|已复核|任务已完成|验证证据|当前分支|工作区|未提交改动|git status|后续：|继续执行|继续补充|OMX|Ralph|hook_prompt|hook_run_id|stop:\d+:|::git-|::archive|thread\/resume)/u.test(trimmed)
+    /(源文件|对应段落|当前块|硬性项|无需修正|没有发现需要|已核对|已复核|任务已完成|验证证据|当前分支|工作区|未提交改动|git status|后续：|继续执行|继续补充|OMX|Ralph|hook_prompt|hook_run_id|stop:\d+:|::git-|::archive|thread\/resume|首现需补双语锚定|补双语锚定|首次出现需补)/u.test(trimmed)
   ) {
     return "draft returned meta/audit text";
   }


### PR DESCRIPTION
## 目的

解 full smoke 新一轮 chunk 1 segment 8 的 \`首现需补双语锚定（Claude Code 首现需补双语锚定）\` 污染。LLM 把 prompt 指令短语直接写进了译文，\`protected_span_integrity\` 抛错。

## 范围（1 commit）

\`a648c3a\` 在 \`getDraftContractViolation\` 的 meta-text 黑名单里追加 \`首现需补双语锚定\`、\`补双语锚定\`、\`首次出现需补\`。命中即视作 contract 违反走重试。

## 验证

- \`npm test\`：baseline failing 124 → 124，零新增回归。
- 后续 full smoke 验证该污染消失。

🤖 Generated with [Claude Code](https://claude.com/claude-code)