### PR TITLE
fix: 合并紧邻中文括号前的同词英文重复

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -3677,7 +3677,25 @@ function collapseRunawayEnglishAnchorChain(text: string): string {
       })
       .join("\n");
   return stripDanglingBoldTail(
-    collapseDoubleBold(collapsePairs(collapseChain(collapseCaseVariantSlashInParens(text))))
+    collapseDoubleBold(
+      collapsePairs(
+        collapseChain(
+          collapseCaseVariantSlashInParens(collapseAdjacentDuplicateEnglishBeforeChineseParen(text))
+        )
+      )
+    )
+  );
+}
+
+// Collapse `Seatbelt Seatbelt（...）` style adjacent-duplicate English word
+// immediately before a Chinese canonical paren. LLM occasionally writes the
+// source phrase AND the anchor canonical form side by side. Safely narrow:
+// only when the exact same English token appears twice separated by a single
+// whitespace and is immediately followed by a Chinese `（...）`.
+function collapseAdjacentDuplicateEnglishBeforeChineseParen(text: string): string {
+  return text.replace(
+    /\b([A-Za-z][A-Za-z0-9.+_-]*)\s+\1(\s*（)/gu,
+    (_match, word, tail) => `${word}${tail}`
   );
 }
 


### PR DESCRIPTION
full smoke chunk 6 segment 7 出现 `Seatbelt Seatbelt（安全框架）` 的 LLM 特异输出，protected_span_integrity 抛错。新增 `collapseAdjacentDuplicateEnglishBeforeChineseParen` 在 `collapseRunawayEnglishAnchorChain` 清理链最前端：仅当同一英文 token 连续两次、紧跟中文 `（` 时合并。零新增回归。