### PR TITLE
feat: P2 step 1 反转 draft lane 默认到 JSON blocks (#14)

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -5880,8 +5880,9 @@ function buildJsonBlockDraftPrompt(source: string): string {
     "2. 每个 block 只写该块对应的中文 Markdown 内容。",
     "3. 不要解释，不要添加额外 block，不要合并或重排。",
     "4. 引用仍是引用，source 中没有 heading 或 code block 的地方，译文中不得凭空新增。",
-    "5. 禁止输出任何任务状态、验证证据、分支信息、工作区状态、git status、路径说明，或“已完成/已核对/已复核/继续执行”之类的元话语。",
-    "6. 禁止输出任何控制面标签或指令文本，例如 <hook_prompt ...>、OMX、Ralph、stop:...、::git-*、::archive 等。",
+    "5. 对标注为 code 的 block：保持原样返回，不要翻译代码、注释或命令输出；如果无法原样返回，可以返回空字符串，程序会把源代码贴回来。",
+    "6. 禁止输出任何任务状态、验证证据、分支信息、工作区状态、git status、路径说明，或“已完成/已核对/已复核/继续执行”之类的元话语。",
+    "7. 禁止输出任何控制面标签或指令文本，例如 <hook_prompt ...>、OMX、Ralph、stop:...、::git-*、::archive 等。",
     "",
     "【按块展开的英文原文】",
     blocks
@@ -5968,7 +5969,12 @@ function reconstructJsonBlockDraft(source: string, jsonText: string): string {
 
   return sourceBlocks
     .map((block, index) => {
-      const translated = typeof translatedBlocks[index] === "string" ? translatedBlocks[index] : "";
+      const translatedRaw = typeof translatedBlocks[index] === "string" ? translatedBlocks[index] : "";
+      // P2: fenced / indented code blocks are not translated. Ignore whatever
+      // the LLM returned for those slots and pin them to the source content so
+      // code cannot be re-wrapped or paraphrased.
+      const kind = classifyPromptBlockKind(block.content);
+      const translated = kind === "code" ? block.content : translatedRaw;
       return index === sourceBlocks.length - 1 ? translated : `${translated}${block.separator}`;
     })
     .join("");
@@ -6014,63 +6020,38 @@ function buildBlockStructuredDraftPrompt(source: string): string {
 }
 
 function classifyStructuralSegmentDraftStrategy(source: string): StructuralSegmentDraftStrategy | null {
+  // P2 (#14) default inversion: every translatable segment goes to the
+  // JSON-blocks lane unless it is a single-line literal (heading /
+  // attribution / kicker). The previous conservative size / kind thresholds
+  // funneled most medium-complexity segments back to freeform, where LLM
+  // specific output pathologies (duplicate blocks, dropped list newlines,
+  // prompt-leak into body, etc.) kept producing a new failure every full
+  // smoke run. Freeform remains available as an explicit fallback when
+  // json-blocks fails schema / contract checks — see translateProtectedSegment.
   const trimmed = source.trim();
-  if (!trimmed || trimmed.includes("\n\n")) {
-    const blocks = splitPromptBlocks(source);
-    if (blocks.length >= 2 && source.length <= 2400) {
-      return { mode: "json-blocks", value: buildJsonBlockDraftPrompt(source), blockCount: blocks.length };
+
+  // Literal opt-outs (single-line, no block splitting needed).
+  if (trimmed && !trimmed.includes("\n\n")) {
+    if (isHeadingLikeBlock(trimmed)) {
+      return { mode: "literal", value: source };
     }
-    const hasBlockquote = blocks.some((block) => classifyPromptBlockKind(block.content) === "blockquote");
-    if (blocks.length >= 4 && hasBlockquote && source.length <= 2200) {
-      return { mode: "json-blocks", value: buildJsonBlockDraftPrompt(source), blockCount: blocks.length };
+    if (isAttributionLikeBlock(trimmed)) {
+      return { mode: "literal", value: source };
     }
-    if (
-      blocks.length === 2 &&
-      isHeadingLikeBlock(blocks[0]?.content?.trim() ?? "") &&
-      classifyPromptBlockKind(blocks[1]?.content?.trim() ?? "") === "paragraph" &&
-      source.length <= 260
-    ) {
-      return { mode: "json-blocks", value: buildJsonBlockDraftPrompt(source), blockCount: blocks.length };
+    if (isNumericKickerLikeBlock(trimmed)) {
+      return { mode: "literal", value: source };
     }
+  }
+
+  const blocks = splitPromptBlocks(source);
+  if (blocks.length === 0) {
     return null;
   }
-
-  if (isHeadingLikeBlock(trimmed)) {
-    return { mode: "literal", value: source };
-  }
-
-  if (isAttributionLikeBlock(trimmed)) {
-    return { mode: "literal", value: source };
-  }
-
-  if (isNumericKickerLikeBlock(trimmed)) {
-    return { mode: "literal", value: source };
-  }
-
-  if (
-    !trimmed.includes("\n") &&
-    classifyPromptBlockKind(trimmed) === "blockquote" &&
-    trimmed.length <= 420
-  ) {
-    return { mode: "json-blocks", value: buildJsonBlockDraftPrompt(source), blockCount: 1 };
-  }
-
-  if (
-    classifyPromptBlockKind(trimmed) === "list" &&
-    source.length <= 900
-  ) {
-    return { mode: "json-blocks", value: buildJsonBlockDraftPrompt(source), blockCount: 1 };
-  }
-
-  if (
-    !trimmed.includes("\n") &&
-    classifyPromptBlockKind(trimmed) === "paragraph" &&
-    trimmed.length <= 220
-  ) {
-    return { mode: "json-blocks", value: buildJsonBlockDraftPrompt(source), blockCount: 1 };
-  }
-
-  return null;
+  return {
+    mode: "json-blocks",
+    value: buildJsonBlockDraftPrompt(source),
+    blockCount: blocks.length
+  };
 }
 
 function buildStructuralSegmentDraftPrompt(


### PR DESCRIPTION
## 目的

P2（#14）第一步：把 draft lane 默认从 freeform 反转到 JSON blocks。freeform 仅保留作为 fallback。

## 背景

详见 #14。总结：前面多次 hotfix（整段重复 / 尾句重复 / 嵌套括注 / case-variant slash / prompt 泄漏 / 同词双写 / 列表合并等）每修一条 LLM 又换一种，guard 累积速度大于解决速度。根因是 freeform 让 LLM 自由生成整段 Markdown，结构保真靠 prompt 自觉，不稳定。JSON blocks 由 schema 强制对齐 block 数，天然消除这些模式。

## 范围（1 commit）

1. \`classifyStructuralSegmentDraftStrategy\` 反转：默认 json-blocks；仅单行 literal（heading / attribution / kicker）opt-out。之前的所有字数上限（多块 <= 2400、list <= 900、blockquote <= 420、paragraph <= 220）全部去掉。
2. \`reconstructJsonBlockDraft\` 对 \`code\` kind 的 block 强制贴回 source 内容，不翻译。
3. \`buildJsonBlockDraftPrompt\` 加一条指令明确 code blocks 保持原样或返回空串（由程序贴回）。

## 验证

- \`npm test\`：baseline failing 124 → 124，零新增回归。
- \`npm run smoke:once -- --fixture full\`：相比 P2 之前的 main，本轮 smoke 不再出现以下 LLM 特异输出：
  - 整段重复 / within-block 尾句重复
  - 列表多项合并一行（fix 前 chunk 4 seg 6/8）
  - Seatbelt Seatbelt 同词双写（fix 前 chunk 6 seg 7）
  - prompt 指令文本泄漏（\`首现需补双语锚定\` 等）
  
  本次 smoke 失败前移到 chunk 3 seg 11 \`Claude Code代码\`——属源文 \`Claude code\` 小写 c 歧义的真正语义 edge case，LLM 判断问题，不是结构 bug，不属 P2 范围。

## 后续（保持 #14 open）

1. 跑 3 次 full smoke 确认 P2 效果稳定；
2. 按 "连续 3 次 smoke 在 guard 被临时 disable 下不触发" 的门槛逐批删除 P1/#171/#8/#9/#12/#13 的 hotfix guard；
3. 视 smoke 结果决定是否调整 json-blocks prompt（例如长段提示、更严格 schema）；
4. Claude code 大小写 edge case 独立 issue 追踪。

🤖 Generated with [Claude Code](https://claude.com/claude-code)