### PR TITLE
fix: 移除 draft meta-text guard 里的 git status 误判

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -6132,7 +6132,7 @@ function getDraftContractViolation(source: string, text: string): string | null 
   if (
     /file:\/\//i.test(trimmed) ||
     /\[[^\]]+\.md\]\(file:\/\//i.test(trimmed) ||
-    /(源文件|对应段落|当前块|硬性项|无需修正|没有发现需要|已核对|已复核|任务已完成|验证证据|当前分支|工作区|未提交改动|git status|后续：|继续执行|继续补充|OMX|Ralph|hook_prompt|hook_run_id|stop:\d+:|::git-|::archive|thread\/resume|首现需补双语锚定|补双语锚定|首次出现需补)/u.test(trimmed)
+    /(源文件|对应段落|当前块|硬性项|无需修正|没有发现需要|已核对|已复核|任务已完成|验证证据|当前分支|工作区|未提交改动|后续：|继续执行|继续补充|OMX|Ralph|hook_prompt|hook_run_id|stop:\d+:|::git-|::archive|thread\/resume|首现需补双语锚定|补双语锚定|首次出现需补)/u.test(trimmed)
   ) {
     return "draft returned meta/audit text";
   }


### PR DESCRIPTION
smoke 推进到 chunk 9/21 Test 4 段，segment 18/19 连续 4 次 draft 失败——fixture 真实使用 `git status, git log, git diff` 作为命令示例，我的 meta-text 黑名单把译文保留的 `git status` 当 OMC / Ralph 泄漏误判。从正则里拿掉 git status（prompt 指令保留）。零新增回归。