### PR TITLE
fix: 已在中文括注内的 chineseHint 不再升级到 canonical (#20)

### DIFF
--- a/src/anchor-normalization.ts
+++ b/src/anchor-normalization.ts
@@ -1612,11 +1612,18 @@ function injectAnchorIntoLine(
       );
     }
 
-    if (text.includes(anchor.chineseHint)) {
+    if (
+      text.includes(anchor.chineseHint) &&
+      !chineseHintIsInsideChineseParen(text, anchor.chineseHint)
+    ) {
       return normalizeExplicitRepairReplacementSpacing(replaceFirst(text, anchor.chineseHint, display.canonical));
     }
 
-    if (display.chineseDisplay && text.includes(display.chineseDisplay)) {
+    if (
+      display.chineseDisplay &&
+      text.includes(display.chineseDisplay) &&
+      !chineseHintIsInsideChineseParen(text, display.chineseDisplay)
+    ) {
       return normalizeExplicitRepairReplacementSpacing(replaceFirst(text, display.chineseDisplay, display.canonical));
     }
 
@@ -1647,15 +1654,38 @@ function injectAnchorIntoLine(
     return text;
   }
 
-  if (text.includes(display.chineseDisplay)) {
+  if (
+    text.includes(display.chineseDisplay) &&
+    !chineseHintIsInsideChineseParen(text, display.chineseDisplay)
+  ) {
     return normalizeExplicitRepairReplacementSpacing(replaceFirst(text, display.chineseDisplay, display.canonical));
   }
 
-  if (text.includes(anchor.chineseHint)) {
+  if (
+    text.includes(anchor.chineseHint) &&
+    !chineseHintIsInsideChineseParen(text, anchor.chineseHint)
+  ) {
     return normalizeExplicitRepairReplacementSpacing(replaceFirst(text, anchor.chineseHint, display.canonical));
   }
 
   return normalizeExplicitRepairReplacementSpacing(text);
+}
+
+function chineseHintIsInsideChineseParen(text: string, chineseHint: string): boolean {
+  const idx = text.indexOf(chineseHint);
+  if (idx < 0) {
+    return false;
+  }
+  for (let i = idx - 1; i >= 0; i -= 1) {
+    const ch = text[i];
+    if (ch === "）") {
+      return false;
+    }
+    if (ch === "（") {
+      return true;
+    }
+  }
+  return false;
 }
 
 function englishIsInsideChineseParen(text: string, english: string): boolean {


### PR DESCRIPTION
full smoke chunk 3 seg 7 产生 `沙盒（沙盒模式（sandbox mode））会创建...` 嵌套双括号。draft LLM 本来写 `沙盒（沙盒模式）` 作为解释，anchor normalization 把内层 `沙盒模式` 替换成 canonical `沙盒模式（sandbox mode）`，嵌套。新增 chineseHintIsInsideChineseParen guard，injectAnchorIntoLine 两个分支（english-primary + chinese-primary）替换前都检查 chineseHint 是否已在中文 `（...）` 内；是则跳过。零新增回归。