### PR TITLE
chore: 从 post-normalizer chain 拿掉 #8 case-variant slash guard (#14)

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -3706,14 +3706,17 @@ function collapseRunawayEnglishAnchorChain(text: string): string {
         return line.replace(/\*\*([\p{P}\p{S}\s]*)$/u, "$1");
       })
       .join("\n");
+  // Issue #14 guard reduction step 1: #8 collapseCaseVariantSlashInParens
+  // temporarily removed from the chain. Three consecutive full-smoke runs
+  // after P2 / #22 did not surface any `X / Y` case-variant slash pattern,
+  // so the guard is no longer needed as a safety net. Function kept for now
+  // to make re-enable trivial if regression appears.
   return stripDanglingBoldTail(
     collapseDoubleBold(
       collapsePairs(
         collapseChain(
-          collapseCaseVariantSlashInParens(
-            collapseAdjacentDuplicateEnglishBeforeChineseParen(
-              collapseNestedChineseEnglishParens(text)
-            )
+          collapseAdjacentDuplicateEnglishBeforeChineseParen(
+            collapseNestedChineseEnglishParens(text)
           )
         )
       )


### PR DESCRIPTION
#14 P2 spec 门槛 "3 次连续 full smoke 不触发就删"——P2 + #22 后 3 次 smoke 没出现 `git / Git` / `Docker / Docker` 模式。移除 collapseRunawayEnglishAnchorChain 对 collapseCaseVariantSlashInParens 的调用。函数保留以便回滚。零新增回归。