### PR TITLE
fix: 翻转 chinese-primary anchor 的反向 English（Chinese）输出

### DIFF
--- a/src/anchor-normalization.ts
+++ b/src/anchor-normalization.ts
@@ -90,7 +90,35 @@ export function normalizeSegmentAnchorText(text: string, slice: PromptSlice | nu
     );
   }
 
+  normalized = flipReversedBilingualForChinesePrimary(normalized, anchors);
   return normalizeRepeatedEnglishParenthesesWithLocalHints(normalized);
+}
+
+// Fix the case where LLM draft emits `English（chineseHint）` (English first)
+// for an anchor whose display_policy is chinese-primary — canonical should be
+// `chineseHint（English）`. Runs after normalizeSingleAnchor so anchor-specific
+// paths have their chance first.
+function flipReversedBilingualForChinesePrimary(
+  text: string,
+  anchors: readonly PromptAnchor[]
+): string {
+  let result = text;
+  for (const anchor of anchors) {
+    if (anchor.displayPolicy !== "chinese-primary") {
+      continue;
+    }
+    const english = anchor.english.trim();
+    const chineseHint = anchor.chineseHint.trim();
+    if (!english || !chineseHint || english.toLowerCase() === chineseHint.toLowerCase()) {
+      continue;
+    }
+    const reversed = `${english}（${chineseHint}）`;
+    const canonical = `${chineseHint}（${english}）`;
+    if (result.includes(reversed) && !result.includes(canonical)) {
+      result = result.split(reversed).join(canonical);
+    }
+  }
+  return result;
 }
 
 export function normalizeSourceSurfaceAnchorText(


### PR DESCRIPTION
chunk 3 seg 5 LLM 把 `Sandbox（沙盒模式）` 写成英文在前（canonical 应为 `沙盒模式（Sandbox）`）。新增 flipReversedBilingualForChinesePrimary，遍历 chinese-primary anchor，检测 `English（chineseHint）` 反向形式则 split-replace 翻转。零新增回归。