### PR TITLE
fix: 清理 canonical 升级后残留的 chineseHint 词缀

### DIFF
--- a/src/anchor-normalization.ts
+++ b/src/anchor-normalization.ts
@@ -1722,9 +1722,17 @@ function injectAnchorIntoLine(
       display.chineseDisplay &&
       englishIsInsideChineseParen(text, display.english)
     ) {
-      return normalizeExplicitRepairReplacementSpacing(
-        replaceWholePhraseOnce(text, display.english, display.canonical)
+      const upgraded = replaceWholePhraseOnce(text, display.english, display.canonical);
+      // Drop a trailing duplicate chineseDisplay that the LLM may have added
+      // next to the bare English (e.g. `npm registry 注册表` -> upgraded to
+      // `npm 注册表（npm registry） 注册表`). Pattern: canonical followed by
+      // optional whitespace + chineseDisplay.
+      const canonicalTrailing = new RegExp(
+        `${escapeRegExp(display.canonical)}\\s*${escapeRegExp(display.chineseDisplay)}`,
+        "g"
       );
+      const cleaned = upgraded.replace(canonicalTrailing, display.canonical);
+      return normalizeExplicitRepairReplacementSpacing(cleaned);
     }
     return text;
   }


### PR DESCRIPTION
LLM draft 写 `npm registry 注册表`（bare 英文 + 中文 gloss），#3 englishIsInsideChineseParen 升级为 canonical 后残留 `npm 注册表（npm registry） 注册表`。在升级分支加 canonical 紧跟 chineseDisplay 的清理。零新增回归。