### PR TITLE
feat: soft-gate 捕获所有 chunk 级错误，fallback 到源 (#14)

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -2575,20 +2575,45 @@ export async function translateMarkdownArticle(source: string, options: Translat
         report(options, "draft", `Skipping ${chunkId}; restored from checkpoint.`);
         continue;
       }
-      const chunkResult = await translateProtectedChunk(chunk, chunkPlan, {
-        state,
-        chunkId,
-        cwd,
-        executor,
-        draftModel,
-        postDraftModel,
-        options,
-        sourcePathHint,
-        spanIndex,
-        nextLocalSpanIndex,
-        draftReasoningEffort: DRAFT_REASONING_EFFORT as ReasoningEffort,
-        postDraftReasoningEffort
-      });
+      let chunkResult;
+      try {
+        chunkResult = await translateProtectedChunk(chunk, chunkPlan, {
+          state,
+          chunkId,
+          cwd,
+          executor,
+          draftModel,
+          postDraftModel,
+          options,
+          sourcePathHint,
+          spanIndex,
+          nextLocalSpanIndex,
+          draftReasoningEffort: DRAFT_REASONING_EFFORT as ReasoningEffort,
+          postDraftReasoningEffort
+        });
+      } catch (error) {
+        // Soft-gate fallback for any chunk-level error (HardGateError from
+        // structural validate, repair contract failures, etc.). Preserve the
+        // protected source for this chunk so the final output.md has a
+        // structurally complete document, just with the failed chunk left in
+        // its English / partial form. Quality checker will surface this.
+        if (!options.softGate) {
+          throw error;
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        report(
+          options,
+          "audit",
+          `Chunk ${chunk.index + 1}/${chunkPlan.chunks.length} (${chunk.headingPath.join(" > ") || "untitled"}): soft-gate caught chunk failure (${message}); falling back to source content.`
+        );
+        const fallbackBody = restoreMarkdownSpans(chunk.source, []);
+        chunkResult = {
+          body: fallbackBody,
+          repairCyclesUsed: 0,
+          gateAudit: createSyntheticChunkFailureAudit(message),
+          nextLocalSpanIndex
+        };
+      }
 
       restoredChunks.push(chunkResult.body + chunk.separatorAfter);
       gateAudits.push(chunkResult.gateAudit);
@@ -2662,6 +2687,20 @@ function resolveStyleMode(optionStyleMode: TranslateOptions["styleMode"]): Style
 
   const raw = process.env.MDZH_STYLE_MODE?.trim().toLowerCase();
   return raw === "final" ? "final" : "none";
+}
+
+function createSyntheticChunkFailureAudit(message: string): GateAudit {
+  return {
+    hard_checks: {
+      paragraph_match: { pass: false, problem: `soft-gate fallback: ${message}` },
+      first_mention_bilingual: { pass: true, problem: "" },
+      numbers_units_logic: { pass: true, problem: "" },
+      chinese_punctuation: { pass: true, problem: "" },
+      unit_conversion_boundary: { pass: true, problem: "" },
+      protected_span_integrity: { pass: true, problem: "" }
+    },
+    must_fix: [`chunk fell back to source content under soft-gate: ${message}`]
+  };
 }
 
 function mergeGateAudits(audits: readonly GateAudit[]): GateAudit {


### PR DESCRIPTION
上一轮 soft-gate 仅处理 chunk-level repair 失败，validateStructuralGateChecks 抛错仍终止 run。本 PR 在 chunk loop 用 try/catch 包住 translateProtectedChunk，softGate 模式下任何 chunk error 都用源内容 fallback，run 继续。output.md 必有，quality checker 决终判。零新增回归。