### PR TITLE
fix: soft-gate fallback 用全文档 spans 还原占位 (#14)

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -2606,7 +2606,7 @@ export async function translateMarkdownArticle(source: string, options: Translat
           "audit",
           `Chunk ${chunk.index + 1}/${chunkPlan.chunks.length} (${chunk.headingPath.join(" > ") || "untitled"}): soft-gate caught chunk failure (${message}); falling back to source content.`
         );
-        const fallbackBody = restoreMarkdownSpans(chunk.source, []);
+        const fallbackBody = restoreMarkdownSpans(chunk.source, spans);
         chunkResult = {
           body: fallbackBody,
           repairCyclesUsed: 0,


### PR DESCRIPTION
soft-gate fallback 之前用空 spans 列表，导致 @@MDZH_* 占位残留触发后续 protected_span_integrity 验证。改用 outer scope 的 spans。零新增回归。