### PR TITLE
fix: soft-gate fallback 过滤 chunk-local 占位 (#14)

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -2606,7 +2606,12 @@ export async function translateMarkdownArticle(source: string, options: Translat
           "audit",
           `Chunk ${chunk.index + 1}/${chunkPlan.chunks.length} (${chunk.headingPath.join(" > ") || "untitled"}): soft-gate caught chunk failure (${message}); falling back to source content.`
         );
-        const fallbackBody = restoreMarkdownSpans(chunk.source, spans);
+        // Pass only spans whose placeholder ID appears in this chunk's source
+        // — restoreMarkdownSpans throws if asked to restore a span absent from
+        // the body, and the document-wide `spans` includes IDs from other
+        // chunks.
+        const chunkSpans = spans.filter((span) => chunk.source.includes(span.id));
+        const fallbackBody = restoreMarkdownSpans(chunk.source, chunkSpans);
         chunkResult = {
           body: fallbackBody,
           repairCyclesUsed: 0,


### PR DESCRIPTION
上轮 fallback 用整文档 spans 调 restoreMarkdownSpans，后者对所有 span 校验占位次数，不属于该 chunk 的 throw。改为按 chunk.source.includes(span.id) 过滤。零新增回归。