### PR TITLE
chore: disable #13 adjacent-duplicate English guard (#14)

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -3764,14 +3764,15 @@ function collapseRunawayEnglishAnchorChain(text: string): string {
   // after P2 / #22 did not surface any `X / Y` case-variant slash pattern,
   // so the guard is no longer needed as a safety net. Function kept for now
   // to make re-enable trivial if regression appears.
+  //
+  // Issue #14 guard reduction step 2: #13 collapseAdjacentDuplicateEnglishBe-
+  // foreChineseParen temporarily removed. Three consecutive post-P2 full-smoke
+  // runs did not surface any `X X（...）` adjacent-duplicate English pattern.
+  // Function body kept to keep revert trivial.
   return stripDanglingBoldTail(
     collapseDoubleBold(
       collapsePairs(
-        collapseChain(
-          collapseAdjacentDuplicateEnglishBeforeChineseParen(
-            collapseNestedChineseEnglishParens(text)
-          )
-        )
+        collapseChain(collapseNestedChineseEnglishParens(text))
       )
     )
   );


### PR DESCRIPTION
P2 guard reduction step 2。3 轮 post-P2 smoke 没触发 `X X（...）` 模式，从 chain 拿掉 collapseAdjacentDuplicateEnglishBeforeChineseParen 调用。函数保留以便回滚。零新增回归。