### PR TITLE
Revert: #14 disable adjacent-duplicate English guard 回退

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -3764,15 +3764,14 @@ function collapseRunawayEnglishAnchorChain(text: string): string {
   // after P2 / #22 did not surface any `X / Y` case-variant slash pattern,
   // so the guard is no longer needed as a safety net. Function kept for now
   // to make re-enable trivial if regression appears.
-  //
-  // Issue #14 guard reduction step 2: #13 collapseAdjacentDuplicateEnglishBe-
-  // foreChineseParen temporarily removed. Three consecutive post-P2 full-smoke
-  // runs did not surface any `X X（...）` adjacent-duplicate English pattern.
-  // Function body kept to keep revert trivial.
   return stripDanglingBoldTail(
     collapseDoubleBold(
       collapsePairs(
-        collapseChain(collapseNestedChineseEnglishParens(text))
+        collapseChain(
+          collapseAdjacentDuplicateEnglishBeforeChineseParen(
+            collapseNestedChineseEnglishParens(text)
+          )
+        )
       )
     )
   );


### PR DESCRIPTION
上轮 PR #36 禁用 collapseAdjacentDuplicateEnglishBeforeChineseParen 导致 full smoke 从 2 issue 跳到 19 issue（多段整句英文未翻译 + nested anchor 重现）。原因未明——该 guard 按预期只处理 `X X(...)` 模式，但实测移除后出现整段翻译缺失。先 revert 恢复 baseline，待独立调查原因。