### PR TITLE
fix: 无条件运行列表项 English+Chinese paren 合并

### DIFF
--- a/src/anchor-normalization.ts
+++ b/src/anchor-normalization.ts
@@ -91,7 +91,16 @@ export function normalizeSegmentAnchorText(text: string, slice: PromptSlice | nu
   }
 
   normalized = flipReversedBilingualForChinesePrimary(normalized, anchors);
-  return normalizeRepeatedEnglishParenthesesWithLocalHints(normalized);
+  const afterLocalHints = normalizeRepeatedEnglishParenthesesWithLocalHints(normalized);
+  // Always run list-item English+Chinese paren merge on every line at the
+  // end. This was previously only reached via injectAnchorIntoLine's internal
+  // normalizeExplicitRepairReplacementSpacing, but LLM draft sometimes
+  // produces `（English）（Chinese）` directly on list items without any
+  // anchor injection firing, leaving the two adjacent parens unmerged.
+  return afterLocalHints
+    .split(/\r?\n/)
+    .map((line) => mergeEnglishAnchorWithAdjacentChineseParenInLine(line))
+    .join("\n");
 }
 
 // Fix the case where LLM draft emits `English（chineseHint）` (English first)


### PR DESCRIPTION
LLM draft 直接写出 `（English）（Chinese）` 且 anchor injection 短路时，列表项的 nested anchor 不会被合并。新加 normalizeSegmentAnchorText 末尾的 per-line pass，无条件运行 mergeEnglishAnchorWithAdjacentChineseParenInLine。零新增回归。