### PR TITLE
fix: repair JSON blocks 失败 fallback 到 text mode (#14)

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -6488,13 +6488,19 @@ async function repairDraftedSegment(
     let lastRepairViolation: string | null = null;
     for (const [attemptIndex, item] of repairPrompts.entries()) {
       if (item.mode === "json-blocks") {
-        const result = await executeJsonBlockRepair(item.prompt, sourceBlockCount);
-        repairResult = {
-          ...result,
-          text: stripControlPlaneContamination(
-            reconstructJsonBlockDraft(draftedSegment.protectedSource, result.text)
-          )
-        };
+        try {
+          const result = await executeJsonBlockRepair(item.prompt, sourceBlockCount);
+          repairResult = {
+            ...result,
+            text: stripControlPlaneContamination(
+              reconstructJsonBlockDraft(draftedSegment.protectedSource, result.text)
+            )
+          };
+        } catch {
+          // JSON block repair failed (e.g. non-JSON response). Skip to next
+          // repair prompt (text mode) which doesn't require structured output.
+          continue;
+        }
       } else {
         const rawRepairResult = await executeRepair(item.prompt, item.useThread);
         repairResult = {


### PR DESCRIPTION
repair 路径 reconstructJsonBlockDraft 没 try/catch。加了后测试从 145→170 pass（净增 25，零回归）。