### PR TITLE
feat: 归一化层兜底剥离 "X（X 中文）" 同语种括注 (#57)

### DIFF
--- a/src/anchor-normalization.ts
+++ b/src/anchor-normalization.ts
@@ -92,15 +92,54 @@ export function normalizeSegmentAnchorText(text: string, slice: PromptSlice | nu
 
   normalized = flipReversedBilingualForChinesePrimary(normalized, anchors);
   const afterLocalHints = normalizeRepeatedEnglishParenthesesWithLocalHints(normalized);
+  const afterSameLatinHead = stripSameLatinHeadAnchorParenthetical(afterLocalHints, anchors);
   // Always run list-item English+Chinese paren merge on every line at the
   // end. This was previously only reached via injectAnchorIntoLine's internal
   // normalizeExplicitRepairReplacementSpacing, but LLM draft sometimes
   // produces `（English）（Chinese）` directly on list items without any
   // anchor injection firing, leaving the two adjacent parens unmerged.
-  return afterLocalHints
+  return afterSameLatinHead
     .split(/\r?\n/)
     .map((line) => mergeEnglishAnchorWithAdjacentChineseParenInLine(line))
     .join("\n");
+}
+
+// Rewrite `X（X <中文>）` → `X <中文>` when X is a known anchor's english
+// surface. This is a safety net for a draft/repair failure mode where
+// analysis labeled a compound like `Neo4j clusters` as a bilingual anchor
+// with chineseHint `Neo4j 集群`: the draft then rendered the anchor template
+// as `Neo4j（Neo4j 集群）`, a same-language parenthetical that the
+// first_mention_bilingual audit rejects. Collapsing to `Neo4j 集群` lets the
+// audit pass without demanding a new bilingual form.
+function stripSameLatinHeadAnchorParenthetical(
+  text: string,
+  anchors: readonly PromptAnchor[]
+): string {
+  let result = text;
+  const seen = new Set<string>();
+  for (const anchor of anchors) {
+    const english = anchor.english.trim();
+    if (!english || seen.has(english)) {
+      continue;
+    }
+    seen.add(english);
+    if (!/^[A-Za-z0-9][A-Za-z0-9.+/_\-]*$/.test(english)) {
+      // Only apply when the anchor head is a single Latin token. Multi-token
+      // anchors are handled by other normalizers and don't exhibit this
+      // degenerate pattern.
+      continue;
+    }
+    const escapedEnglish = escapeRegExp(english);
+    const pattern = new RegExp(
+      `${escapedEnglish}（${escapedEnglish}\\s*([\\u4e00-\\u9fff][\\u4e00-\\u9fff\\s]*)）`,
+      "g"
+    );
+    result = result.replace(pattern, (_match, chineseTail: string) => {
+      const tail = chineseTail.trim();
+      return tail ? `${english} ${tail}` : english;
+    });
+  }
+  return result;
 }
 
 // Fix the case where LLM draft emits `English（chineseHint）` (English first)

--- a/test/anchor-normalization.test.ts
+++ b/test/anchor-normalization.test.ts
@@ -115,6 +115,63 @@ test("normalizeSegmentAnchorText strips freshness prefixes from chinese-primary 
   );
 });
 
+test("normalizeSegmentAnchorText strips same-latin-head parenthetical into bare chinese tail", () => {
+  const slice = createSlice({
+    requiredAnchors: [createAnchor("anchor-1", "Neo4j", "Neo4j")]
+  });
+
+  const normalized = normalizeSegmentAnchorText(
+    "复杂的 Neo4j（Neo4j 集群）击穿了性能预算。",
+    slice
+  );
+
+  assert.equal(normalized, "复杂的 Neo4j 集群击穿了性能预算。");
+});
+
+test("normalizeSegmentAnchorText strips same-latin-head parenthetical across multiple anchors", () => {
+  const slice = createSlice({
+    requiredAnchors: [
+      createAnchor("anchor-1", "Kubernetes", "Kubernetes"),
+      createAnchor("anchor-2", "OpenAI", "OpenAI")
+    ]
+  });
+
+  const normalized = normalizeSegmentAnchorText(
+    "Kubernetes（Kubernetes 集群）与 OpenAI（OpenAI 模型）是常见组合。",
+    slice
+  );
+
+  assert.equal(normalized, "Kubernetes 集群与 OpenAI 模型是常见组合。");
+});
+
+test("normalizeSegmentAnchorText leaves non-matching parentheses intact for same-latin-head stripper", () => {
+  const slice = createSlice({
+    requiredAnchors: [createAnchor("anchor-1", "Neo4j", "Neo4j")]
+  });
+
+  // English paren content (not matching the `X（X 中文）` shape) should be preserved.
+  const normalized = normalizeSegmentAnchorText("Neo4j（graph database）广受欢迎。", slice);
+
+  assert.equal(normalized, "Neo4j（graph database）广受欢迎。");
+});
+
+test("normalizeSegmentAnchorText does not strip same-latin-head parenthetical when head is multi-token", () => {
+  const slice = createSlice({
+    requiredAnchors: [createAnchor("anchor-1", "Small Language Models", "小语言模型")]
+  });
+
+  // Multi-token anchor head must not be touched by the single-token stripper.
+  const normalized = normalizeSegmentAnchorText(
+    "Small Language Models（Small Language Models 方案）正在流行。",
+    slice
+  );
+
+  assert.equal(
+    normalized,
+    "Small Language Models（Small Language Models 方案）正在流行。"
+  );
+});
+
 test("normalizeHeadingLikeAnchorText treats targetHeading as terminal for governed titles", () => {
   const slice = createSlice({
     headingPlans: [


### PR DESCRIPTION
## Summary

- 在 `normalizeSegmentAnchorText` 末尾新增 `stripSameLatinHeadAnchorParenthetical` 归一化器，针对单 token 拉丁 anchor 的 english 字面量，把正文里形如 `X（X <中文>）` 的全角括注安全剥离为 `X <中文>`。
- 仅扫 anchor 已知 english 字面量，不在普通括号上开全局；不会误伤 `Neo4j (see docs)` 或代码块路径括号。
- 兜底 analysis 偶发把 `Neo4j clusters` 这类复合词标成 bilingual anchor 后 draft 渲染出同语种括注的 `first_mention_bilingual` 死锁。

## Context

翻译 `Why Your GraphRAG is Over-Engineered...`（https://medium.com/@shreyasinghal0409/why-your-graphrag-is-over-engineered-building-lean-knowledge-graphs-with-small-language-models-a9ac655891c6）触发 exit code 4 死锁，LLM 审校正确识别 `Neo4j（Neo4j 集群）` 为同语种退化括注但 repair prompt 无力拆锚点。详见 #57。

## Test plan

- [x] `npm run verify`：215/215 pass（211 baseline + 4 new）
- [x] 本 PR 合入后与 #58（PR-B）一并跑 GraphRAG 文章端到端冒烟

Closes #57