### PR TITLE
feat: analysis 层拒绝"拉丁专名 + 纯小写英文 tail"复合锚点 (#58)

### DIFF
--- a/src/known-entities.ts
+++ b/src/known-entities.ts
@@ -638,7 +638,60 @@ function classifyDiscoveredAnchorRejection(anchor: AnalysisAnchor): string | nul
     return "code-like surface form should not be promoted into anchor catalog";
   }
 
+  if (looksLikeLatinHeadGenericTailCompound(anchor)) {
+    return "latin-head + lowercase english tail compound should not be promoted as bilingual anchor";
+  }
+
   return null;
+}
+
+// Reject compound anchors of the form "<Latin proper-noun head> <lowercase
+// english tail>" whose chineseHint is the head passed through plus a Chinese
+// tail — e.g. `Neo4j clusters` + `Neo4j 集群`. These force the draft to render
+// `Head（Head <中文>）`, a same-language parenthetical that the
+// first_mention_bilingual audit rejects without any repair path.
+//
+// The rule is deliberately narrow so it does NOT match:
+//   - Title Case compound tails (`Claude Code`, `Knowledge Graphs`, `Small Language Models`)
+//   - chineseHints that don't start with the head (legitimately translated terms)
+function looksLikeLatinHeadGenericTailCompound(anchor: AnalysisAnchor): boolean {
+  const english = anchor.english.trim();
+  const chineseHint = anchor.chineseHint?.trim() ?? "";
+  if (!english || !chineseHint) {
+    return false;
+  }
+
+  const tokens = english.split(/\s+/).filter((token) => token.length > 0);
+  if (tokens.length < 2) {
+    return false;
+  }
+
+  const head = tokens[0];
+  const tail = tokens.slice(1);
+  if (!head) {
+    return false;
+  }
+
+  if (!/^[A-Za-z0-9][A-Za-z0-9.+/_-]*$/.test(head) || !/[A-Z]/.test(head)) {
+    return false;
+  }
+
+  if (!tail.every((token) => /^[a-z]+s?$/.test(token))) {
+    return false;
+  }
+
+  const lowerHint = chineseHint.toLowerCase();
+  const lowerHead = head.toLowerCase();
+  if (!lowerHint.startsWith(lowerHead)) {
+    return false;
+  }
+
+  const remainder = chineseHint.slice(head.length).trim();
+  if (!remainder) {
+    return false;
+  }
+
+  return /^[\u4e00-\u9fff][\u4e00-\u9fff\s]*$/.test(remainder);
 }
 
 function looksLikeCliFlagSurface(value: string): boolean {

--- a/test/known-entities.test.ts
+++ b/test/known-entities.test.ts
@@ -496,6 +496,198 @@ test("normalizeDiscoveredAnchorCatalog rejects discovered config-path anchors", 
   ]);
 });
 
+test("normalizeDiscoveredAnchorCatalog rejects latin-head + lowercase english tail compound anchors", () => {
+  const state = createTranslationRunState({
+    sourcePathHint: "sample.md",
+    documentTitle: "Sample",
+    frontmatterPresent: false,
+    protectedSpans: [],
+    chunks: [
+      {
+        source: "Neo4j clusters hit a scaling wall.\n",
+        separatorAfter: "",
+        headingPath: ["Sample"],
+        segments: [
+          {
+            kind: "translatable",
+            source: "Neo4j clusters hit a scaling wall.\n",
+            separatorAfter: "",
+            spanIds: [],
+            headingHints: [],
+            specialNotes: []
+          }
+        ]
+      }
+    ]
+  });
+
+  const normalized = normalizeDiscoveredAnchorCatalog(state, {
+    anchors: [
+      {
+        english: "Neo4j clusters",
+        chineseHint: "Neo4j 集群",
+        familyKey: "neo4j-clusters",
+        displayPolicy: "chinese-primary",
+        sourceForms: ["Neo4j clusters"],
+        firstOccurrence: {
+          chunkId: "chunk-1",
+          segmentId: "chunk-1-segment-1"
+        }
+      }
+    ],
+    ignoredTerms: []
+  });
+
+  assert.equal(normalized.anchors.length, 0);
+  assert.deepEqual(normalized.ignoredTerms, [
+    {
+      english: "Neo4j clusters",
+      reason: "latin-head + lowercase english tail compound should not be promoted as bilingual anchor"
+    }
+  ]);
+});
+
+test("normalizeDiscoveredAnchorCatalog rejects latin-head + lowercase tail when head contains digits and hyphen", () => {
+  const state = createTranslationRunState({
+    sourcePathHint: "sample.md",
+    documentTitle: "Sample",
+    frontmatterPresent: false,
+    protectedSpans: [],
+    chunks: [
+      {
+        source: "GPT-4 models outperform older baselines.\n",
+        separatorAfter: "",
+        headingPath: ["Sample"],
+        segments: [
+          {
+            kind: "translatable",
+            source: "GPT-4 models outperform older baselines.\n",
+            separatorAfter: "",
+            spanIds: [],
+            headingHints: [],
+            specialNotes: []
+          }
+        ]
+      }
+    ]
+  });
+
+  const normalized = normalizeDiscoveredAnchorCatalog(state, {
+    anchors: [
+      {
+        english: "GPT-4 models",
+        chineseHint: "GPT-4 模型",
+        familyKey: "gpt-4-models",
+        displayPolicy: "chinese-primary",
+        sourceForms: ["GPT-4 models"],
+        firstOccurrence: {
+          chunkId: "chunk-1",
+          segmentId: "chunk-1-segment-1"
+        }
+      }
+    ],
+    ignoredTerms: []
+  });
+
+  assert.equal(normalized.anchors.length, 0);
+  assert.equal(normalized.ignoredTerms.length, 1);
+  assert.equal(normalized.ignoredTerms[0]?.english, "GPT-4 models");
+});
+
+test("normalizeDiscoveredAnchorCatalog keeps Title Case compound anchors (Claude Code)", () => {
+  const state = createTranslationRunState({
+    sourcePathHint: "sample.md",
+    documentTitle: "Sample",
+    frontmatterPresent: false,
+    protectedSpans: [],
+    chunks: [
+      {
+        source: "Claude Code is a new CLI.\n",
+        separatorAfter: "",
+        headingPath: ["Sample"],
+        segments: [
+          {
+            kind: "translatable",
+            source: "Claude Code is a new CLI.\n",
+            separatorAfter: "",
+            spanIds: [],
+            headingHints: [],
+            specialNotes: []
+          }
+        ]
+      }
+    ]
+  });
+
+  const normalized = normalizeDiscoveredAnchorCatalog(state, {
+    anchors: [
+      {
+        english: "Claude Code",
+        chineseHint: "Claude 代码",
+        familyKey: "claude-code",
+        displayPolicy: "english-primary",
+        sourceForms: ["Claude Code"],
+        firstOccurrence: {
+          chunkId: "chunk-1",
+          segmentId: "chunk-1-segment-1"
+        }
+      }
+    ],
+    ignoredTerms: []
+  });
+
+  assert.equal(normalized.anchors.length, 1);
+  assert.equal(normalized.anchors[0]?.english, "Claude Code");
+  assert.equal(normalized.ignoredTerms.length, 0);
+});
+
+test("normalizeDiscoveredAnchorCatalog keeps compound anchors whose chineseHint does not start with the head (Knowledge Graphs)", () => {
+  const state = createTranslationRunState({
+    sourcePathHint: "sample.md",
+    documentTitle: "Sample",
+    frontmatterPresent: false,
+    protectedSpans: [],
+    chunks: [
+      {
+        source: "Knowledge Graphs combine facts.\n",
+        separatorAfter: "",
+        headingPath: ["Sample"],
+        segments: [
+          {
+            kind: "translatable",
+            source: "Knowledge Graphs combine facts.\n",
+            separatorAfter: "",
+            spanIds: [],
+            headingHints: [],
+            specialNotes: []
+          }
+        ]
+      }
+    ]
+  });
+
+  const normalized = normalizeDiscoveredAnchorCatalog(state, {
+    anchors: [
+      {
+        english: "Knowledge Graphs",
+        chineseHint: "知识图谱",
+        familyKey: "knowledge-graphs",
+        displayPolicy: "chinese-primary",
+        sourceForms: ["Knowledge Graphs"],
+        firstOccurrence: {
+          chunkId: "chunk-1",
+          segmentId: "chunk-1-segment-1"
+        }
+      }
+    ],
+    ignoredTerms: []
+  });
+
+  assert.equal(normalized.anchors.length, 1);
+  assert.equal(normalized.anchors[0]?.english, "Knowledge Graphs");
+  assert.equal(normalized.ignoredTerms.length, 0);
+});
+
 test("writeKnownEntityCandidatesIfRequested persists unknown anchors into a candidate file", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "mdzh-known-entities-"));
   const outputPath = path.join(tempDir, "known_entities_candidates.json");


### PR DESCRIPTION
## Summary

- 在 `classifyDiscoveredAnchorRejection()` 新增 `looksLikeLatinHeadGenericTailCompound` 窄规则：english 分词 >= 2 token、head 含大写字母、所有非首 token 纯小写（可选复数 s）、chineseHint 为 head 原样前缀 + 纯中文尾，全部满足才拒绝并写入 `ignoredTerms`。
- 命中：`Neo4j clusters` + `Neo4j 集群`、`Kubernetes clusters`、`OpenAI models`、`GPT-4 models`。
- 显式放过：`Claude Code`、`Knowledge Graphs`、`Small Language Models`（Title Case tail 或 chineseHint 不以 head 开头）。

## Context

翻译 `Why Your GraphRAG is Over-Engineered...`（https://medium.com/@shreyasinghal0409/why-your-graphrag-is-over-engineered-building-lean-knowledge-graphs-with-small-language-models-a9ac655891c6）触发 first_mention_bilingual 死锁：analysis 把 `Neo4j clusters` 标成 bilingual anchor，chineseHint `Neo4j 集群` 让 draft 渲染出 `Neo4j（Neo4j 集群）`。详见 #58。

与 #59（PR-A）构成"上游 + 中游"双层防御：源头剔除 + 归一化兜底。

## Test plan

- [x] `npm run verify`：215/215 pass（211 baseline + 4 new）
- [x] 本 PR 合入后与 #59（PR-A）一并跑 GraphRAG 文章端到端冒烟

Closes #58