### PR TITLE
feat: analysis 层拒绝转置 chineseHint (#61)

### DIFF
--- a/src/known-entities.ts
+++ b/src/known-entities.ts
@@ -638,7 +638,74 @@ function classifyDiscoveredAnchorRejection(anchor: AnalysisAnchor): string | nul
     return "code-like surface form should not be promoted into anchor catalog";
   }
 
+  if (looksLikeTransposedBilingualHint(anchor)) {
+    return "chineseHint sandwiches an english subtoken of the anchor, which breaks bold / bilingual rendering";
+  }
+
   return null;
+}
+
+// Reject anchors whose chineseHint sandwiches an English subtoken of the
+// anchor's own `english` between Chinese characters — e.g.
+// `Schema-First Extraction` + `先 Schema 抽取`. The canonical renders as
+// `先 Schema 抽取（Schema-First Extraction）`, which forces the draft to emit a
+// Chinese-English-Chinese sandwich inside `**...**` bold spans; the LLM then
+// breaks the bold markers and repeats the leading Chinese character, causing
+// a protected_span_integrity failure with no repair path.
+//
+// The rule is narrow:
+//   - only fires when the English in chineseHint is a non-trivial (>=3 chars)
+//     subtoken of the anchor's own english (case-insensitive), so unrelated
+//     English like `OSS` inside a Chinese explanation is left alone;
+//   - requires Chinese on BOTH sides of the English subtoken inside the hint,
+//     so clean prefixes (`Claude 代码`) and suffixes (`概念 Context`) that
+//     existing strippers already handle cleanly are not rejected.
+function looksLikeTransposedBilingualHint(anchor: AnalysisAnchor): boolean {
+  const english = anchor.english.trim();
+  const chineseHint = anchor.chineseHint?.trim() ?? "";
+  if (!english || !chineseHint) {
+    return false;
+  }
+
+  const hasChinese = /[\u4e00-\u9fff]/u.test(chineseHint);
+  const hasEnglish = /[A-Za-z]/.test(chineseHint);
+  if (!hasChinese || !hasEnglish) {
+    return false;
+  }
+
+  const englishRuns = chineseHint.match(/[A-Za-z][A-Za-z0-9]*/g) ?? [];
+  if (englishRuns.length === 0) {
+    return false;
+  }
+
+  const englishSubtokens = new Set(
+    english
+      .split(/[\s.\-_/+]+/u)
+      .map((token) => token.trim().toLowerCase())
+      .filter((token) => token.length >= 3)
+  );
+  if (englishSubtokens.size === 0) {
+    return false;
+  }
+
+  for (const run of englishRuns) {
+    if (!englishSubtokens.has(run.toLowerCase())) {
+      continue;
+    }
+
+    const runIndex = chineseHint.indexOf(run);
+    if (runIndex < 0) {
+      continue;
+    }
+
+    const before = chineseHint.slice(0, runIndex);
+    const after = chineseHint.slice(runIndex + run.length);
+    if (/[\u4e00-\u9fff]/u.test(before) && /[\u4e00-\u9fff]/u.test(after)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function looksLikeCliFlagSurface(value: string): boolean {

--- a/test/known-entities.test.ts
+++ b/test/known-entities.test.ts
@@ -496,6 +496,199 @@ test("normalizeDiscoveredAnchorCatalog rejects discovered config-path anchors", 
   ]);
 });
 
+test("normalizeDiscoveredAnchorCatalog rejects anchors whose chineseHint sandwiches an english subtoken", () => {
+  const state = createTranslationRunState({
+    sourcePathHint: "sample.md",
+    documentTitle: "Sample",
+    frontmatterPresent: false,
+    protectedSpans: [],
+    chunks: [
+      {
+        source: "Instead, we use a **Schema-First Extraction** method.\n",
+        separatorAfter: "",
+        headingPath: ["Sample"],
+        segments: [
+          {
+            kind: "translatable",
+            source: "Instead, we use a **Schema-First Extraction** method.\n",
+            separatorAfter: "",
+            spanIds: [],
+            headingHints: [],
+            specialNotes: []
+          }
+        ]
+      }
+    ]
+  });
+
+  const normalized = normalizeDiscoveredAnchorCatalog(state, {
+    anchors: [
+      {
+        english: "Schema-First Extraction",
+        chineseHint: "先 Schema 抽取",
+        familyKey: "schema-first-extraction",
+        displayPolicy: "acronym-compound",
+        sourceForms: ["Schema-First Extraction"],
+        firstOccurrence: {
+          chunkId: "chunk-1",
+          segmentId: "chunk-1-segment-1"
+        }
+      }
+    ],
+    ignoredTerms: []
+  });
+
+  assert.equal(normalized.anchors.length, 0);
+  assert.deepEqual(normalized.ignoredTerms, [
+    {
+      english: "Schema-First Extraction",
+      reason:
+        "chineseHint sandwiches an english subtoken of the anchor, which breaks bold / bilingual rendering"
+    }
+  ]);
+});
+
+test("normalizeDiscoveredAnchorCatalog keeps anchors with an english prefix followed by Chinese", () => {
+  const state = createTranslationRunState({
+    sourcePathHint: "sample.md",
+    documentTitle: "Sample",
+    frontmatterPresent: false,
+    protectedSpans: [],
+    chunks: [
+      {
+        source: "Try Claude Code today.\n",
+        separatorAfter: "",
+        headingPath: ["Sample"],
+        segments: [
+          {
+            kind: "translatable",
+            source: "Try Claude Code today.\n",
+            separatorAfter: "",
+            spanIds: [],
+            headingHints: [],
+            specialNotes: []
+          }
+        ]
+      }
+    ]
+  });
+
+  const normalized = normalizeDiscoveredAnchorCatalog(state, {
+    anchors: [
+      {
+        english: "Claude Code",
+        chineseHint: "Claude 代码",
+        familyKey: "claude-code",
+        displayPolicy: "english-primary",
+        sourceForms: ["Claude Code"],
+        firstOccurrence: {
+          chunkId: "chunk-1",
+          segmentId: "chunk-1-segment-1"
+        }
+      }
+    ],
+    ignoredTerms: []
+  });
+
+  assert.equal(normalized.anchors.length, 1);
+  assert.equal(normalized.anchors[0]?.english, "Claude Code");
+  assert.deepEqual(normalized.ignoredTerms, []);
+});
+
+test("normalizeDiscoveredAnchorCatalog keeps anchors whose chineseHint contains no english", () => {
+  const state = createTranslationRunState({
+    sourcePathHint: "sample.md",
+    documentTitle: "Sample",
+    frontmatterPresent: false,
+    protectedSpans: [],
+    chunks: [
+      {
+        source: "SLMs can index your corpus locally.\n",
+        separatorAfter: "",
+        headingPath: ["Sample"],
+        segments: [
+          {
+            kind: "translatable",
+            source: "SLMs can index your corpus locally.\n",
+            separatorAfter: "",
+            spanIds: [],
+            headingHints: [],
+            specialNotes: []
+          }
+        ]
+      }
+    ]
+  });
+
+  const normalized = normalizeDiscoveredAnchorCatalog(state, {
+    anchors: [
+      {
+        english: "SLMs",
+        chineseHint: "小语言模型",
+        familyKey: "slms",
+        displayPolicy: "acronym-compound",
+        sourceForms: ["SLMs"],
+        firstOccurrence: {
+          chunkId: "chunk-1",
+          segmentId: "chunk-1-segment-1"
+        }
+      }
+    ],
+    ignoredTerms: []
+  });
+
+  assert.equal(normalized.anchors.length, 1);
+  assert.equal(normalized.anchors[0]?.english, "SLMs");
+  assert.deepEqual(normalized.ignoredTerms, []);
+});
+
+test("normalizeDiscoveredAnchorCatalog keeps anchors whose hint english is unrelated to the anchor english", () => {
+  const state = createTranslationRunState({
+    sourcePathHint: "sample.md",
+    documentTitle: "Sample",
+    frontmatterPresent: false,
+    protectedSpans: [],
+    chunks: [
+      {
+        source: "This paper covers Knowledge Graphs end-to-end.\n",
+        separatorAfter: "",
+        headingPath: ["Sample"],
+        segments: [
+          {
+            kind: "translatable",
+            source: "This paper covers Knowledge Graphs end-to-end.\n",
+            separatorAfter: "",
+            spanIds: [],
+            headingHints: [],
+            specialNotes: []
+          }
+        ]
+      }
+    ]
+  });
+
+  const normalized = normalizeDiscoveredAnchorCatalog(state, {
+    anchors: [
+      {
+        english: "Knowledge Graphs",
+        chineseHint: "知识图谱（KG）汇总",
+        familyKey: "knowledge-graphs",
+        displayPolicy: "chinese-primary",
+        sourceForms: ["Knowledge Graphs"],
+        firstOccurrence: {
+          chunkId: "chunk-1",
+          segmentId: "chunk-1-segment-1"
+        }
+      }
+    ],
+    ignoredTerms: []
+  });
+
+  assert.equal(normalized.anchors.length, 1);
+  assert.equal(normalized.anchors[0]?.english, "Knowledge Graphs");
+  assert.deepEqual(normalized.ignoredTerms, []);
+});
+
 test("writeKnownEntityCandidatesIfRequested persists unknown anchors into a candidate file", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "mdzh-known-entities-"));
   const outputPath = path.join(tempDir, "known_entities_candidates.json");


### PR DESCRIPTION
## Summary

修复 #61。新增一条窄范围的 discovered anchor 拒绝规则，切断 GraphRAG 文档复现的 `**Schema-First Extraction**` → `protected_span_integrity` 死锁。

## 根因

analysis 层给 `Schema-First Extraction` 打了 `acronym-compound`，chineseHint `先 Schema 抽取` 把英文子词 `Schema` 夹在两个中文字之间。`resolveAnchorDisplay` 按 `chineseHint（english）` 模板渲染成 `先 Schema 抽取（Schema-First Extraction）`，draft 在 `**...**` 里无法稳定输出"中-英-中-中文括号-英文"的夹心，于是咬坏加粗、重复首字（`先 先 Schema 抽取`），进入无法 repair 的死循环。

## Change

`classifyDiscoveredAnchorRejection` 新增 `looksLikeTransposedBilingualHint`：

- 必须同时有中英
- hint 里出现的 ASCII run 是 anchor.english 的 ≥3 字符子词（大小写不敏感）
- 该 run **两侧都出现中文**

三条全命中才剔除，兜底由后续 draft 自然渲染（`Schema-First Extraction` 在正文自然译出中文 tail，不再走复合锚点路径）。

窄 scope — 不触及：
- 前缀型：`Claude Code` + `Claude 代码`
- 后缀型：`... Context` + `概念 Context`
- 无关英文：`Knowledge Graphs` + `知识图谱（KG）汇总`
- 无英文：`SLMs` + `小语言模型`

## Test plan

- [x] `npm run verify` — 215/215 通过（211 基线 + 4 条新增边界测试）
- [ ] 本地合并 #57/#58/#61 后重跑 GraphRAG 原文，exit 0
- [ ] 确认 `Neo4j clusters` 仍为 `Neo4j 集群`（无复合括注），`Knowledge Graphs` 仍为 `知识图谱（Knowledge Graphs）`

## 范围

只改 `src/known-entities.ts`（+68）与 `test/known-entities.test.ts`（+192）。scheme-h.ts prompt 不动。Direction 3 repair-prompt hint 留给后续 issue。

Fixes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)