### PR TITLE
feat: emphasisPlan targetText 剥离转置括注污染 (#63)

### DIFF
--- a/src/known-entities.ts
+++ b/src/known-entities.ts
@@ -638,7 +638,74 @@ function classifyDiscoveredAnchorRejection(anchor: AnalysisAnchor): string | nul
     return "code-like surface form should not be promoted into anchor catalog";
   }
 
+  if (looksLikeTransposedBilingualHint(anchor)) {
+    return "chineseHint sandwiches an english subtoken of the anchor, which breaks bold / bilingual rendering";
+  }
+
   return null;
+}
+
+// Reject anchors whose chineseHint sandwiches an English subtoken of the
+// anchor's own `english` between Chinese characters — e.g.
+// `Schema-First Extraction` + `先 Schema 抽取`. The canonical renders as
+// `先 Schema 抽取（Schema-First Extraction）`, which forces the draft to emit a
+// Chinese-English-Chinese sandwich inside `**...**` bold spans; the LLM then
+// breaks the bold markers and repeats the leading Chinese character, causing
+// a protected_span_integrity failure with no repair path.
+//
+// The rule is narrow:
+//   - only fires when the English in chineseHint is a non-trivial (>=3 chars)
+//     subtoken of the anchor's own english (case-insensitive), so unrelated
+//     English like `OSS` inside a Chinese explanation is left alone;
+//   - requires Chinese on BOTH sides of the English subtoken inside the hint,
+//     so clean prefixes (`Claude 代码`) and suffixes (`概念 Context`) that
+//     existing strippers already handle cleanly are not rejected.
+function looksLikeTransposedBilingualHint(anchor: AnalysisAnchor): boolean {
+  const english = anchor.english.trim();
+  const chineseHint = anchor.chineseHint?.trim() ?? "";
+  if (!english || !chineseHint) {
+    return false;
+  }
+
+  const hasChinese = /[\u4e00-\u9fff]/u.test(chineseHint);
+  const hasEnglish = /[A-Za-z]/.test(chineseHint);
+  if (!hasChinese || !hasEnglish) {
+    return false;
+  }
+
+  const englishRuns = chineseHint.match(/[A-Za-z][A-Za-z0-9]*/g) ?? [];
+  if (englishRuns.length === 0) {
+    return false;
+  }
+
+  const englishSubtokens = new Set(
+    english
+      .split(/[\s.\-_/+]+/u)
+      .map((token) => token.trim().toLowerCase())
+      .filter((token) => token.length >= 3)
+  );
+  if (englishSubtokens.size === 0) {
+    return false;
+  }
+
+  for (const run of englishRuns) {
+    if (!englishSubtokens.has(run.toLowerCase())) {
+      continue;
+    }
+
+    const runIndex = chineseHint.indexOf(run);
+    if (runIndex < 0) {
+      continue;
+    }
+
+    const before = chineseHint.slice(0, runIndex);
+    const after = chineseHint.slice(runIndex + run.length);
+    if (/[\u4e00-\u9fff]/u.test(before) && /[\u4e00-\u9fff]/u.test(after)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function looksLikeCliFlagSurface(value: string): boolean {

--- a/src/known-entities.ts
+++ b/src/known-entities.ts
@@ -238,13 +238,21 @@ function normalizeDiscoveredEmphasisPlans(
       }
       return extractSegmentStrongEmphasisSourceTexts(segment.source).includes(plan.sourceText.trim().toLowerCase());
     })
-    .map((plan) => ({
-      ...plan,
-      sourceText: plan.sourceText.trim(),
-      ...(typeof plan.emphasisIndex === "number" ? { emphasisIndex: plan.emphasisIndex } : {}),
-      ...(typeof plan.lineIndex === "number" ? { lineIndex: plan.lineIndex } : {}),
-      ...(plan.targetText?.trim() ? { targetText: plan.targetText.trim() } : {})
-    }));
+    .map((plan) => {
+      const trimmedSource = plan.sourceText.trim();
+      const trimmedTarget = plan.targetText?.trim() ?? "";
+      const keepTarget =
+        trimmedTarget.length > 0 && !hasTransposedBilingualSandwich(trimmedSource, trimmedTarget);
+      const { targetText: _omitTarget, ...rest } = plan;
+      void _omitTarget;
+      return {
+        ...rest,
+        sourceText: trimmedSource,
+        ...(typeof plan.emphasisIndex === "number" ? { emphasisIndex: plan.emphasisIndex } : {}),
+        ...(typeof plan.lineIndex === "number" ? { lineIndex: plan.lineIndex } : {}),
+        ...(keepTarget ? { targetText: trimmedTarget } : {})
+      };
+    });
 }
 
 function mergeBlockPlans(formalPlans: AnchorCatalog["blockPlans"], discoveredPlans: AnchorCatalog["blockPlans"]) {
@@ -661,25 +669,33 @@ function classifyDiscoveredAnchorRejection(anchor: AnalysisAnchor): string | nul
 //     so clean prefixes (`Claude 代码`) and suffixes (`概念 Context`) that
 //     existing strippers already handle cleanly are not rejected.
 function looksLikeTransposedBilingualHint(anchor: AnalysisAnchor): boolean {
-  const english = anchor.english.trim();
-  const chineseHint = anchor.chineseHint?.trim() ?? "";
-  if (!english || !chineseHint) {
+  return hasTransposedBilingualSandwich(anchor.english, anchor.chineseHint ?? "");
+}
+
+// Detects the "transposed bilingual sandwich" pattern: the Chinese-bearing body
+// contains an English subtoken of the source anchor, and Chinese characters sit
+// on BOTH sides of that English run. Used both for rejecting bad discovered
+// anchors (chineseHint) and for stripping bad emphasis-plan targetText values.
+export function hasTransposedBilingualSandwich(english: string, body: string): boolean {
+  const head = english.trim();
+  const text = body.trim();
+  if (!head || !text) {
     return false;
   }
 
-  const hasChinese = /[\u4e00-\u9fff]/u.test(chineseHint);
-  const hasEnglish = /[A-Za-z]/.test(chineseHint);
+  const hasChinese = /[\u4e00-\u9fff]/u.test(text);
+  const hasEnglish = /[A-Za-z]/.test(text);
   if (!hasChinese || !hasEnglish) {
     return false;
   }
 
-  const englishRuns = chineseHint.match(/[A-Za-z][A-Za-z0-9]*/g) ?? [];
+  const englishRuns = text.match(/[A-Za-z][A-Za-z0-9]*/g) ?? [];
   if (englishRuns.length === 0) {
     return false;
   }
 
   const englishSubtokens = new Set(
-    english
+    head
       .split(/[\s.\-_/+]+/u)
       .map((token) => token.trim().toLowerCase())
       .filter((token) => token.length >= 3)
@@ -693,15 +709,20 @@ function looksLikeTransposedBilingualHint(anchor: AnalysisAnchor): boolean {
       continue;
     }
 
-    const runIndex = chineseHint.indexOf(run);
-    if (runIndex < 0) {
-      continue;
-    }
+    let searchFrom = 0;
+    while (searchFrom < text.length) {
+      const runIndex = text.indexOf(run, searchFrom);
+      if (runIndex < 0) {
+        break;
+      }
 
-    const before = chineseHint.slice(0, runIndex);
-    const after = chineseHint.slice(runIndex + run.length);
-    if (/[\u4e00-\u9fff]/u.test(before) && /[\u4e00-\u9fff]/u.test(after)) {
-      return true;
+      const before = text.slice(0, runIndex);
+      const after = text.slice(runIndex + run.length);
+      if (/[\u4e00-\u9fff]/u.test(before) && /[\u4e00-\u9fff]/u.test(after)) {
+        return true;
+      }
+
+      searchFrom = runIndex + run.length;
     }
   }
 

--- a/test/known-entities.test.ts
+++ b/test/known-entities.test.ts
@@ -689,6 +689,146 @@ test("normalizeDiscoveredAnchorCatalog keeps anchors whose hint english is unrel
   assert.deepEqual(normalized.ignoredTerms, []);
 });
 
+test("normalizeDiscoveredAnchorCatalog strips emphasisPlan targetText that sandwiches english subtokens in chinese", () => {
+  const state = createTranslationRunState({
+    sourcePathHint: "sample.md",
+    documentTitle: "Sample",
+    frontmatterPresent: false,
+    protectedSpans: [],
+    chunks: [
+      {
+        source: "Instead, we use a **Schema-First Extraction** method.\n",
+        separatorAfter: "",
+        headingPath: ["Sample"],
+        segments: [
+          {
+            kind: "translatable",
+            source: "Instead, we use a **Schema-First Extraction** method.\n",
+            separatorAfter: "",
+            spanIds: [],
+            headingHints: [],
+            specialNotes: []
+          }
+        ]
+      }
+    ]
+  });
+
+  const normalized = normalizeDiscoveredAnchorCatalog(state, {
+    anchors: [],
+    ignoredTerms: [],
+    emphasisPlans: [
+      {
+        chunkId: "chunk-1",
+        segmentId: "chunk-1-segment-1",
+        sourceText: "Schema-First Extraction",
+        strategy: "preserve-strong",
+        emphasisIndex: 1,
+        lineIndex: 1,
+        targetText: "Schema-First Extraction（先 Schema 提取）",
+        governedTerms: ["Schema-First Extraction"]
+      }
+    ]
+  });
+
+  assert.equal(normalized.emphasisPlans?.length, 1);
+  const plan = normalized.emphasisPlans?.[0];
+  assert.equal(plan?.sourceText, "Schema-First Extraction");
+  assert.equal(plan?.targetText, undefined);
+});
+
+test("normalizeDiscoveredAnchorCatalog keeps emphasisPlan targetText that is a pure chinese parenthetical", () => {
+  const state = createTranslationRunState({
+    sourcePathHint: "sample.md",
+    documentTitle: "Sample",
+    frontmatterPresent: false,
+    protectedSpans: [],
+    chunks: [
+      {
+        source: "We rely on **GraphRAG** today.\n",
+        separatorAfter: "",
+        headingPath: ["Sample"],
+        segments: [
+          {
+            kind: "translatable",
+            source: "We rely on **GraphRAG** today.\n",
+            separatorAfter: "",
+            spanIds: [],
+            headingHints: [],
+            specialNotes: []
+          }
+        ]
+      }
+    ]
+  });
+
+  const normalized = normalizeDiscoveredAnchorCatalog(state, {
+    anchors: [],
+    ignoredTerms: [],
+    emphasisPlans: [
+      {
+        chunkId: "chunk-1",
+        segmentId: "chunk-1-segment-1",
+        sourceText: "GraphRAG",
+        strategy: "preserve-strong",
+        emphasisIndex: 1,
+        lineIndex: 1,
+        targetText: "GraphRAG（图谱增强检索）",
+        governedTerms: ["GraphRAG"]
+      }
+    ]
+  });
+
+  assert.equal(normalized.emphasisPlans?.length, 1);
+  assert.equal(normalized.emphasisPlans?.[0]?.targetText, "GraphRAG（图谱增强检索）");
+});
+
+test("normalizeDiscoveredAnchorCatalog passes through emphasisPlans with no targetText unchanged", () => {
+  const state = createTranslationRunState({
+    sourcePathHint: "sample.md",
+    documentTitle: "Sample",
+    frontmatterPresent: false,
+    protectedSpans: [],
+    chunks: [
+      {
+        source: "Run **Ollama** locally.\n",
+        separatorAfter: "",
+        headingPath: ["Sample"],
+        segments: [
+          {
+            kind: "translatable",
+            source: "Run **Ollama** locally.\n",
+            separatorAfter: "",
+            spanIds: [],
+            headingHints: [],
+            specialNotes: []
+          }
+        ]
+      }
+    ]
+  });
+
+  const normalized = normalizeDiscoveredAnchorCatalog(state, {
+    anchors: [],
+    ignoredTerms: [],
+    emphasisPlans: [
+      {
+        chunkId: "chunk-1",
+        segmentId: "chunk-1-segment-1",
+        sourceText: "Ollama",
+        strategy: "preserve-strong",
+        emphasisIndex: 1,
+        lineIndex: 1,
+        governedTerms: ["Ollama"]
+      }
+    ]
+  });
+
+  assert.equal(normalized.emphasisPlans?.length, 1);
+  assert.equal(normalized.emphasisPlans?.[0]?.sourceText, "Ollama");
+  assert.equal(normalized.emphasisPlans?.[0]?.targetText, undefined);
+});
+
 test("writeKnownEntityCandidatesIfRequested persists unknown anchors into a candidate file", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "mdzh-known-entities-"));
   const outputPath = path.join(tempDir, "known_entities_candidates.json");

--- a/test/known-entities.test.ts
+++ b/test/known-entities.test.ts
@@ -496,6 +496,199 @@ test("normalizeDiscoveredAnchorCatalog rejects discovered config-path anchors", 
   ]);
 });
 
+test("normalizeDiscoveredAnchorCatalog rejects anchors whose chineseHint sandwiches an english subtoken", () => {
+  const state = createTranslationRunState({
+    sourcePathHint: "sample.md",
+    documentTitle: "Sample",
+    frontmatterPresent: false,
+    protectedSpans: [],
+    chunks: [
+      {
+        source: "Instead, we use a **Schema-First Extraction** method.\n",
+        separatorAfter: "",
+        headingPath: ["Sample"],
+        segments: [
+          {
+            kind: "translatable",
+            source: "Instead, we use a **Schema-First Extraction** method.\n",
+            separatorAfter: "",
+            spanIds: [],
+            headingHints: [],
+            specialNotes: []
+          }
+        ]
+      }
+    ]
+  });
+
+  const normalized = normalizeDiscoveredAnchorCatalog(state, {
+    anchors: [
+      {
+        english: "Schema-First Extraction",
+        chineseHint: "先 Schema 抽取",
+        familyKey: "schema-first-extraction",
+        displayPolicy: "acronym-compound",
+        sourceForms: ["Schema-First Extraction"],
+        firstOccurrence: {
+          chunkId: "chunk-1",
+          segmentId: "chunk-1-segment-1"
+        }
+      }
+    ],
+    ignoredTerms: []
+  });
+
+  assert.equal(normalized.anchors.length, 0);
+  assert.deepEqual(normalized.ignoredTerms, [
+    {
+      english: "Schema-First Extraction",
+      reason:
+        "chineseHint sandwiches an english subtoken of the anchor, which breaks bold / bilingual rendering"
+    }
+  ]);
+});
+
+test("normalizeDiscoveredAnchorCatalog keeps anchors with an english prefix followed by Chinese", () => {
+  const state = createTranslationRunState({
+    sourcePathHint: "sample.md",
+    documentTitle: "Sample",
+    frontmatterPresent: false,
+    protectedSpans: [],
+    chunks: [
+      {
+        source: "Try Claude Code today.\n",
+        separatorAfter: "",
+        headingPath: ["Sample"],
+        segments: [
+          {
+            kind: "translatable",
+            source: "Try Claude Code today.\n",
+            separatorAfter: "",
+            spanIds: [],
+            headingHints: [],
+            specialNotes: []
+          }
+        ]
+      }
+    ]
+  });
+
+  const normalized = normalizeDiscoveredAnchorCatalog(state, {
+    anchors: [
+      {
+        english: "Claude Code",
+        chineseHint: "Claude 代码",
+        familyKey: "claude-code",
+        displayPolicy: "english-primary",
+        sourceForms: ["Claude Code"],
+        firstOccurrence: {
+          chunkId: "chunk-1",
+          segmentId: "chunk-1-segment-1"
+        }
+      }
+    ],
+    ignoredTerms: []
+  });
+
+  assert.equal(normalized.anchors.length, 1);
+  assert.equal(normalized.anchors[0]?.english, "Claude Code");
+  assert.deepEqual(normalized.ignoredTerms, []);
+});
+
+test("normalizeDiscoveredAnchorCatalog keeps anchors whose chineseHint contains no english", () => {
+  const state = createTranslationRunState({
+    sourcePathHint: "sample.md",
+    documentTitle: "Sample",
+    frontmatterPresent: false,
+    protectedSpans: [],
+    chunks: [
+      {
+        source: "SLMs can index your corpus locally.\n",
+        separatorAfter: "",
+        headingPath: ["Sample"],
+        segments: [
+          {
+            kind: "translatable",
+            source: "SLMs can index your corpus locally.\n",
+            separatorAfter: "",
+            spanIds: [],
+            headingHints: [],
+            specialNotes: []
+          }
+        ]
+      }
+    ]
+  });
+
+  const normalized = normalizeDiscoveredAnchorCatalog(state, {
+    anchors: [
+      {
+        english: "SLMs",
+        chineseHint: "小语言模型",
+        familyKey: "slms",
+        displayPolicy: "acronym-compound",
+        sourceForms: ["SLMs"],
+        firstOccurrence: {
+          chunkId: "chunk-1",
+          segmentId: "chunk-1-segment-1"
+        }
+      }
+    ],
+    ignoredTerms: []
+  });
+
+  assert.equal(normalized.anchors.length, 1);
+  assert.equal(normalized.anchors[0]?.english, "SLMs");
+  assert.deepEqual(normalized.ignoredTerms, []);
+});
+
+test("normalizeDiscoveredAnchorCatalog keeps anchors whose hint english is unrelated to the anchor english", () => {
+  const state = createTranslationRunState({
+    sourcePathHint: "sample.md",
+    documentTitle: "Sample",
+    frontmatterPresent: false,
+    protectedSpans: [],
+    chunks: [
+      {
+        source: "This paper covers Knowledge Graphs end-to-end.\n",
+        separatorAfter: "",
+        headingPath: ["Sample"],
+        segments: [
+          {
+            kind: "translatable",
+            source: "This paper covers Knowledge Graphs end-to-end.\n",
+            separatorAfter: "",
+            spanIds: [],
+            headingHints: [],
+            specialNotes: []
+          }
+        ]
+      }
+    ]
+  });
+
+  const normalized = normalizeDiscoveredAnchorCatalog(state, {
+    anchors: [
+      {
+        english: "Knowledge Graphs",
+        chineseHint: "知识图谱（KG）汇总",
+        familyKey: "knowledge-graphs",
+        displayPolicy: "chinese-primary",
+        sourceForms: ["Knowledge Graphs"],
+        firstOccurrence: {
+          chunkId: "chunk-1",
+          segmentId: "chunk-1-segment-1"
+        }
+      }
+    ],
+    ignoredTerms: []
+  });
+
+  assert.equal(normalized.anchors.length, 1);
+  assert.equal(normalized.anchors[0]?.english, "Knowledge Graphs");
+  assert.deepEqual(normalized.ignoredTerms, []);
+});
+
 test("writeKnownEntityCandidatesIfRequested persists unknown anchors into a candidate file", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "mdzh-known-entities-"));
   const outputPath = path.join(tempDir, "known_entities_candidates.json");


### PR DESCRIPTION
## Summary

- \`normalizeDiscoveredEmphasisPlans\` 对 LLM 产出的 emphasis plan \`targetText\` 加校验：命中"英文 head + 括注里夹英文子词 + 两侧中文"转置形态时，剥掉 \`targetText\`，保留 plan 标记 bold 边界。
- 把 #61 的判别逻辑抽成可复用 \`hasTransposedBilingualSandwich(english, body)\`，同时用于 anchor rejection 和 emphasis plan target 校验，避免两处维护相同规则。
- 新增 3 条 unit test，覆盖：坏 targetText 被剥离、干净中文括注 \`GraphRAG（图谱增强检索）\` 被保留、无 targetText 透传。

解决 #63。依赖 #62（复用其新增的判别内核）；#62 合入后本 PR rebase 自动变得更薄。

## 背景

#61 在 analysis 层拒绝了 \`Schema-First Extraction\` 这类 anchor，但真实跑 GraphRAG 文章端到端仍然 \`exit 4\` —— \`emphasisPlans.targetText\` 是一条独立轨道，从 LLM 分析直接穿透到 draft，带来同样的坏模板。证据见 #63 issue。

## Test plan

- [x] \`npm run verify\` → 218/0 pass
- [ ] smoke 分支合入 #57+#58+#61+#62+#63 后重跑 GraphRAG 端到端：EXIT=0 且 \`**Schema-First Extraction**\` 不污染
- [ ] 人工 diff 确认其他 emphasis plan bilingual 括注（如 \`GraphRAG（...）\`）未受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)