### PR TITLE
fix: inject paragraph_match missing-source guidance into repair prompt (#67)

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -6828,6 +6828,32 @@ function belongToSameConceptFamily(left: string, right: string): boolean {
   );
 }
 
+function extractParagraphMatchMissingSources(mustFix: readonly string[]): string[] {
+  const missing = new Set<string>();
+  for (const raw of mustFix) {
+    const item = raw ?? "";
+    const mentionsParagraphMatch =
+      /paragraph_match/i.test(item) ||
+      item.includes("段落对应") ||
+      item.includes("段落数") ||
+      item.includes("段落不对齐") ||
+      item.includes("缺少原文") ||
+      /漏[翻译]/.test(item);
+    if (!mentionsParagraphMatch) {
+      continue;
+    }
+    const quotePattern = /["“]([^"”\n]{8,})["”]/g;
+    let match: RegExpExecArray | null;
+    while ((match = quotePattern.exec(item)) != null) {
+      const text = match[1]?.trim();
+      if (text && text.length >= 8) {
+        missing.add(text);
+      }
+    }
+  }
+  return [...missing];
+}
+
 function buildRepairPromptContext(
   promptContext: ChunkPromptContext,
   mustFix: readonly string[]
@@ -7094,6 +7120,17 @@ function buildRepairPromptContext(
     extraNotes.push(
       "本次 must_fix 明确指出当前译文擅自把原文普通文本改成了 inline code。修复时如果原文中的路径、目录名、文件名、URL 片段或命令样式文本本来没有反引号，就必须保持普通文本结构，不要新增反引号或把它们包成 inline code。",
       "对列表项里的 `~/.ssh/`、`~/.aws/`、`~/.config/` 这类路径，如果原文只是普通列表文本加括注说明，修复时应继续保持普通列表文本，只调整双语说明或中文解释；不要把路径本身改成代码样式。"
+    );
+  }
+
+  const paragraphMatchMissingSources = extractParagraphMatchMissingSources(mustFix);
+  if (paragraphMatchMissingSources.length > 0) {
+    const quoted = paragraphMatchMissingSources.map((text) => `"${text}"`).join(" | ");
+    extraNotes.push(
+      `本次 must_fix 明确指出当前段落或标题块漏翻了以下原文片段：${quoted}。`,
+      "paragraph_match 硬失败的本质是“内容缺失”而非排版问题：修复时必须把这些原文片段完整译成中文并接回当前段落，不得以“保持标题风格”“局部补丁”“已检查”“与原文一致”为理由省略、压缩或只润色旧译文。",
+      "如果当前段落是 Markdown 标题或加粗标题，把新译文接在标题现有文本之后，必要时用逗号、句号、破折号或括号串联，整段仍保持为单一标题节点（不得拆行、不得新增独立段落）。",
+      "输出的修订译文相对当前译文必须明显变长，且新增内容要与上述原文逐句对应；严禁只重新排版或返回几乎相同的句子。"
     );
   }
 

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -1668,6 +1668,36 @@ test("translateMarkdownArticle repeats in-sentence repair guidance when must_fix
   assert.match(notes, /不要把修复转移到同一分段的前一句、后一句、标题、列表项或总结句里/);
 });
 
+test("buildRepairPromptContext injects paragraph_match missing-source guidance when audit quotes an unfixed sentence (#67)", () => {
+  const context = buildRepairPromptContextForTest(
+    createMinimalChunkPromptContext(),
+    [
+      "第 1 个标题块的译文缺少原文后半句\"because they look great on both the mobile app and desktop, and they won't get messed up by the publication's formatting rules.\"，需补全整句含义并保持标题结构。",
+      "硬性检查 paragraph_match 未通过：标题译文只覆盖了原句前半部分，缺少后半句内容，和原文不严格对应。"
+    ]
+  );
+
+  const notes = context.specialNotes.join("\n");
+  assert.match(notes, /当前段落或标题块漏翻了以下原文片段/);
+  assert.match(notes, /because they look great on both the mobile app and desktop/);
+  assert.match(notes, /paragraph_match 硬失败的本质是“内容缺失”而非排版问题/);
+  assert.match(notes, /整段仍保持为单一标题节点/);
+  assert.match(notes, /输出的修订译文相对当前译文必须明显变长/);
+});
+
+test("buildRepairPromptContext does not emit paragraph_match guidance for unrelated must_fix items (#67)", () => {
+  const context = buildRepairPromptContextForTest(
+    createMinimalChunkPromptContext(),
+    [
+      "当前句“But you need to understand what kind of access your Claude Code AI agents need.”中，首次出现的“sandboxes”未补中英对照。"
+    ]
+  );
+
+  const notes = context.specialNotes.join("\n");
+  assert.doesNotMatch(notes, /paragraph_match 硬失败的本质是“内容缺失”/);
+  assert.doesNotMatch(notes, /当前段落或标题块漏翻了以下原文片段/);
+});
+
 test("translateMarkdownArticle surfaces IR targets in repair guidance when pending repairs are already bound", () => {
   const context = buildRepairPromptContextForTest(
     createMinimalChunkPromptContext({


### PR DESCRIPTION
## Summary

`#65 / #66` 的 soft-gate 治理模型落地后，端到端冒烟在 GraphRAG 文章上暴露出 `paragraph_match` 结构硬门被触发的死角：audit 已一字不差引用漏翻的整句，repair 2 轮仍补不回来（LLM 在标题语境下倾向保留短句、不给完整整句），最终仍 exit 4。

本 PR 把 "audit 已点名、repair 不动" 的顺从缺口在 prompt 层补齐。

## 变更

- 新增 `extractParagraphMatchMissingSources()`（`src/translate.ts`）：从 `must_fix` 文本中识别 \`paragraph_match\`/\`段落对应\`/\`缺少原文\`/\`漏翻\` 信号，再抽取双引号（直/弯）包裹的 ≥8 字符原文片段。
- 在 `buildRepairPromptContext` 末尾命中上述 case 时注入 4 条强约束：
  - 明示 "内容缺失" 而非排版，不得借 "局部补丁/已检查" 省略。
  - 标题/加粗标题要保持单一节点，把译文接回原节点。
  - 修订译文相对当前译文必须明显变长，新增部分与原文逐句对应。
  - 严禁 \"已检查 / 与原文一致\" 式空操作。
- 新增 2 条单元测试验证触发与不触发条件。

## Verification

- `npm run verify`: **213/213 green**（211 + 2 新测试）。
- 端到端再跑 GraphRAG 正在进行；LLM 侧失败是多病灶（本轮抽到 \`protected_span_integrity\`，是独立结构硬门，不属于本 PR 范围），若再次抽到 \`paragraph_match\` 将作为独立补充测试记录。

## Related

Closes #67。关联 #66（soft-gate 默认化）、#57 #58 #61 #63。

🤖 Generated with [Claude Code](https://claude.com/claude-code)