### PR TITLE
fix: reject repair output with stacked English parens or raw bold leaks (#69)

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -6288,6 +6288,18 @@ function getDraftContractViolation(source: string, text: string): string | null 
     return source.trim() ? "draft returned empty content" : null;
   }
 
+  // Issue #69 (B): reject repair output that emits raw `**` markers when the
+  // protected source had zero raw `**` (all bold spans are placeholder-tokenized
+  // as `@@MDZH_STRONG_EMPHASIS_NNNN@@`). Raw `**` leaking through means the LLM
+  // invented bold markup, which corrupts span boundaries downstream. Runs
+  // before block-kind checks because a single-line `**X**` otherwise triggers
+  // the heading misclassification branch first and hides the root cause.
+  const sourceBoldCount = (source.match(/\*\*/g) ?? []).length;
+  const draftBoldCount = (trimmed.match(/\*\*/g) ?? []).length;
+  if (sourceBoldCount === 0 && draftBoldCount > 0) {
+    return `draft introduced raw bold markers (** x ${draftBoldCount}) not present in the protected source`;
+  }
+
   const trimmedSource = source.trim();
   if (trimmed === trimmedSource) {
     const strippedSource = trimmedSource
@@ -6373,6 +6385,41 @@ function getDraftContractViolation(source: string, text: string): string | null 
 
   if (source.length > 0 && trimmed.length > source.length * 2.8) {
     return "draft expanded far beyond the source segment length";
+  }
+
+  // Issue #69 (A): reject repair output that stacks the same English term in
+  // two adjacent parenthetical annotations, e.g.
+  // `（Small Language Models (SLMs)）（SLMs）` or `（SLMs）（SLMs）`. This pattern
+  // emerges when repair over-fixes a first_mention_bilingual audit hint inside
+  // a protected bold span; the downstream collapse helper only catches 3+
+  // adjacent duplicates, so two-window stacks leak through to audit.
+  const parenWindowPattern = /（\s*([A-Za-z][A-Za-z0-9 .+/_\-()]*?)\s*）/gu;
+  const parenWindows: { start: number; end: number; innerKey: string }[] = [];
+  for (const match of trimmed.matchAll(parenWindowPattern)) {
+    const inner = match[1]!.toLowerCase().replace(/[^a-z0-9]/g, "");
+    if (inner.length === 0) {
+      continue;
+    }
+    parenWindows.push({
+      start: match.index!,
+      end: match.index! + match[0].length,
+      innerKey: inner
+    });
+  }
+  for (let i = 1; i < parenWindows.length; i += 1) {
+    const prev = parenWindows[i - 1]!;
+    const curr = parenWindows[i]!;
+    const between = trimmed.slice(prev.end, curr.start);
+    if (!/^[\s*]*$/.test(between)) {
+      continue;
+    }
+    const a = prev.innerKey;
+    const b = curr.innerKey;
+    if (a === b || a.includes(b) || b.includes(a)) {
+      const snippetStart = Math.max(0, prev.start - 10);
+      const snippetEnd = Math.min(trimmed.length, curr.end + 10);
+      return `draft stacked duplicate English parenthetical annotation near: ${trimmed.slice(snippetStart, snippetEnd)}`;
+    }
   }
 
   return null;
@@ -7145,6 +7192,10 @@ export function buildRepairPromptContextForTest(
   mustFix: readonly string[]
 ): ChunkPromptContext {
   return buildRepairPromptContext(promptContext, mustFix);
+}
+
+export function getDraftContractViolationForTest(source: string, text: string): string | null {
+  return getDraftContractViolation(source, text);
 }
 
 function collectDuplicatePendingAnchorGroups(promptContext: ChunkPromptContext): string[][] {

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -9,6 +9,7 @@ import { planMarkdownChunks } from "../src/markdown-chunks.js";
 import { extractFrontmatter, protectMarkdownSpans } from "../src/markdown-protection.js";
 import {
   buildRepairPromptContextForTest,
+  getDraftContractViolationForTest,
   parseGateAudit,
   translateMarkdownArticle,
   type ChunkPromptContext,
@@ -1696,6 +1697,40 @@ test("buildRepairPromptContext does not emit paragraph_match guidance for unrela
   const notes = context.specialNotes.join("\n");
   assert.doesNotMatch(notes, /paragraph_match 硬失败的本质是“内容缺失”/);
   assert.doesNotMatch(notes, /当前段落或标题块漏翻了以下原文片段/);
+});
+
+test("getDraftContractViolation rejects adjacent duplicate English parenthetical annotations (#69)", () => {
+  const violation = getDraftContractViolationForTest(
+    "@@MDZH_STRONG_EMPHASIS_0001@@",
+    "小语言模型（Small Language Models (SLMs)）（SLMs）"
+  );
+  assert.ok(violation, "expected a violation string, got null");
+  assert.match(violation!, /stacked duplicate English parenthetical/);
+});
+
+test("getDraftContractViolation allows a single English parenthetical annotation (#69)", () => {
+  const violation = getDraftContractViolationForTest(
+    "@@MDZH_STRONG_EMPHASIS_0001@@",
+    "小语言模型（Small Language Models (SLMs)）"
+  );
+  assert.equal(violation, null);
+});
+
+test("getDraftContractViolation rejects raw bold markers when protected source had none (#69)", () => {
+  const violation = getDraftContractViolationForTest(
+    "@@MDZH_STRONG_EMPHASIS_0001@@",
+    "**小语言模型**和**"
+  );
+  assert.ok(violation, "expected a violation string, got null");
+  assert.match(violation!, /introduced raw bold markers/);
+});
+
+test("getDraftContractViolation preserves raw bold markers when the source already contained them (#69)", () => {
+  const violation = getDraftContractViolationForTest(
+    "这是**原文本身**带有的加粗片段",
+    "这是**译文**保留的加粗片段"
+  );
+  assert.equal(violation, null);
 });
 
 test("translateMarkdownArticle surfaces IR targets in repair guidance when pending repairs are already bound", () => {


### PR DESCRIPTION
## 背景

#66（默认软门）+ #68（paragraph_match repair 注入）合并后，GraphRAG 冒烟又撞到第 5 轮结构性失败：repair 在"补首现双语锚定"时啃坏加粗块并叠加同一英文术语的括注。

观察样本：

```
源：**Small Language Models (SLMs)**
repair：**小语言模型（Small Language Models (SLMs)）（SLMs）**（SLMs）**和**
```

两个信号：

- **A（语义叠加）** 同一英文术语 `SLMs` 在 2+ 个相邻 `（...）` 注解里连续出现。下游 `collapseRunawayEnglishAnchorChain` 只收 3+ 组相邻相同英文形，2 组漏网。
- **B（结构泄漏）** repair 输出里出现裸 `**` 而 `protectedSource` 已把 `**` 全部 placeholder 化 (`@@MDZH_STRONG_EMPHASIS_NNNN@@`)。出现 = LLM 自造或规范器误注。

## 改动

`getDraftContractViolation`（`src/translate.ts`）新增两条检查：

- 检查 A：扫所有 `（English）` 窗口，相邻两个仅被空白/`*` 分隔、foldCase 后互为子串 → 返回违约。
- 检查 B：`source.match(/\*\*/g)` 计数为 0 而 `trimmed.match(/\*\*/g)` 非 0 → 返回违约。放在函数顶部避免单行 `**X**` 先被 block-kind 分支误判成 heading。

违约字符串进入现有重试循环（`src/translate.ts:6561`），打日志 → 走下一个 stricter prompt → 两轮仍失败则走 #66 软/硬门分流。零改动 repair prompt 模板 / collapse 规则 / `markdown-protection.ts`。

## 验证

```bash
npm run verify
# 219/219 全绿（原 215 + 本 PR 新增 4 条单测 A/B 正反）
```

端到端冒烟：

```bash
cd .../Why-Your-GraphRAG-is-Over-Engineered-.../
npx md-zh-translate --input index.md --output index-zh-new.md
# EXIT=0，输出 6.7KB，9 对 ** 结构完整
# 本次 LLM 未造 #69 症状，新检查未触发；防御层随时就位
```

## 关联

- Closes #69
- 依赖：#66（soft-gate 默认）#68（paragraph_match 注入）

🤖 Generated with [Claude Code](https://claude.com/claude-code)