### PR TITLE
fix: inject first_mention_bilingual cut-piece recipe into repair prompt (#71)

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -6901,6 +6901,38 @@ function extractParagraphMatchMissingSources(mustFix: readonly string[]): string
   return [...missing];
 }
 
+function extractFirstMentionBilingualTargets(mustFix: readonly string[]): string[] {
+  const targets = new Set<string>();
+  for (const raw of mustFix) {
+    const item = raw ?? "";
+    const mentionsFirstMention =
+      /first_mention_bilingual/i.test(item) ||
+      ((item.includes("首次出现") || item.includes("首现")) &&
+        (item.includes("中英") ||
+          item.includes("双语") ||
+          item.includes("对照") ||
+          item.includes("英文原名")));
+    if (!mentionsFirstMention) {
+      continue;
+    }
+    for (const match of item.matchAll(/[“"`']([A-Za-z][A-Za-z0-9./+&:_ -]{0,79})[”"`']/g)) {
+      const candidate = match[1]?.trim();
+      if (candidate && /[A-Za-z]/.test(candidate)) {
+        targets.add(candidate);
+      }
+    }
+    for (const match of item.matchAll(
+      /(?:核心术语|术语|英文目标|英文词|英文原名|产品名|工具名|项目名|模型名|CLI 名称|命令名|框架名|平台名|机制名|概念|首次出现的|首现的)\s+([A-Za-z][A-Za-z0-9./+&:_ -]{0,79}?)(?=\s*(?:首次|首现|在|需|应|未|缺少|没有|作为|并|，|。|；|：|$))/g
+    )) {
+      const candidate = match[1]?.trim();
+      if (candidate && /[A-Za-z]/.test(candidate)) {
+        targets.add(candidate);
+      }
+    }
+  }
+  return [...targets];
+}
+
 function buildRepairPromptContext(
   promptContext: ChunkPromptContext,
   mustFix: readonly string[]
@@ -7178,6 +7210,19 @@ function buildRepairPromptContext(
       "paragraph_match 硬失败的本质是“内容缺失”而非排版问题：修复时必须把这些原文片段完整译成中文并接回当前段落，不得以“保持标题风格”“局部补丁”“已检查”“与原文一致”为理由省略、压缩或只润色旧译文。",
       "如果当前段落是 Markdown 标题或加粗标题，把新译文接在标题现有文本之后，必要时用逗号、句号、破折号或括号串联，整段仍保持为单一标题节点（不得拆行、不得新增独立段落）。",
       "输出的修订译文相对当前译文必须明显变长，且新增内容要与上述原文逐句对应；严禁只重新排版或返回几乎相同的句子。"
+    );
+  }
+
+  const firstMentionBilingualTargets = extractFirstMentionBilingualTargets(mustFix);
+  if (firstMentionBilingualTargets.length > 0) {
+    const joined = firstMentionBilingualTargets.join(" / ");
+    extraNotes.push(
+      `本次 must_fix 指向 first_mention_bilingual 硬失败：以下英文专名或术语在首现位置缺少中英双语锚定：${joined}。`,
+      "修复流程分两步：(1) 先检查当前译文里该英文词对应的中文译名是否已经出现；(2) 按下面的切片变换在对应首现位置就地补齐。不要另起一段、另开列表项，也不要把锚点挪到标题或总结句里。",
+      "切片 A——译文里已经有该概念的中文译名（例如“波音 747”“实体-关系”），直接在该中文译名之后紧跟一层括注写成“中文译名（English）”，例如“波音 747（Boeing 747）”；不要在同一段其他位置再重复这个英文原名。",
+      "切片 B——译文完全漏掉该概念，就在最自然的首现位置补“中文译名（English）”整串，保持单层括注；不要写成“English（中文译名）”倒装形式，也不要只补英文原名。",
+      "严禁以下回避写法：(a) 同一英文原名在同段生成相邻重复括注，例如“（Boeing 747）（Boeing 747）”；(b) 双层括号如“（中文（English））”；(c) 把该英文原名改成 inline code 或加粗；(d) 用“英文原名直接当作中文”的等价省略写法。",
+      "如果 must_fix 同时点名多个英文目标，必须在各自的首现位置分别补齐；不要因为其中一个已经补过，就认为整段已经达标。"
     );
   }
 

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -1733,6 +1733,48 @@ test("getDraftContractViolation preserves raw bold markers when the source alrea
   assert.equal(violation, null);
 });
 
+test("buildRepairPromptContext injects first_mention_bilingual cut-piece guidance when must_fix quotes an English target (#71)", () => {
+  const context = buildRepairPromptContextForTest(
+    createMinimalChunkPromptContext(),
+    [
+      "第 2 个列表项中\"Boeing 747\"首次出现未按要求补中英文对照，需在该处直接补齐。"
+    ]
+  );
+
+  const notes = context.specialNotes.join("\n");
+  assert.match(notes, /first_mention_bilingual 硬失败/);
+  assert.match(notes, /Boeing 747/);
+  assert.match(notes, /切片 A——译文里已经有该概念的中文译名/);
+  assert.match(notes, /切片 B——译文完全漏掉该概念/);
+  assert.match(notes, /相邻重复括注/);
+});
+
+test("buildRepairPromptContext catches first_mention_bilingual signals phrased as 首现/双语 (#71)", () => {
+  const context = buildRepairPromptContextForTest(
+    createMinimalChunkPromptContext(),
+    [
+      "在当前引用句中，\"Entity-Relationship\" 首现位置缺少双语锚定，需要补齐。"
+    ]
+  );
+
+  const notes = context.specialNotes.join("\n");
+  assert.match(notes, /first_mention_bilingual 硬失败/);
+  assert.match(notes, /Entity-Relationship/);
+});
+
+test("buildRepairPromptContext does not emit first_mention_bilingual guidance for unrelated must_fix items (#71)", () => {
+  const context = buildRepairPromptContextForTest(
+    createMinimalChunkPromptContext(),
+    [
+      "硬性检查 paragraph_match 未通过：标题译文只覆盖了原句前半部分。"
+    ]
+  );
+
+  const notes = context.specialNotes.join("\n");
+  assert.doesNotMatch(notes, /first_mention_bilingual 硬失败/);
+  assert.doesNotMatch(notes, /切片 A——译文里已经有该概念的中文译名/);
+});
+
 test("translateMarkdownArticle surfaces IR targets in repair guidance when pending repairs are already bound", () => {
   const context = buildRepairPromptContextForTest(
     createMinimalChunkPromptContext({


### PR DESCRIPTION
## Summary

修复 analysis 层漏锚导致的 first_mention_bilingual 软门触发。当 must_fix 点名英文目标（如 `"Boeing 747"`）+ 首现/中英对照/双语锚定信号时，repair prompt 现在注入具体的切片变换配方。

## 实现

- 新增 `extractFirstMentionBilingualTargets(mustFix)`：过滤 `first_mention_bilingual` / `首现 + 中英/双语/对照` 信号，复用 `extractExplicitEnglishTargetsFromMustFix` 的引号 + 命名词抽取逻辑。
- 在 `buildRepairPromptContext` 的 paragraph_match 注入块之后，新增 first_mention_bilingual 专用的 extraNotes 块：
  - **切片 A**：译文已有中文译名 → 就地追加 `（English）` 单层括注 → `波音 747（Boeing 747）`
  - **切片 B**：译文完全漏掉 → 在首现位置补 `中文译名（English）`
  - 明确禁止：相邻重复括注、双层括号、inline code、省略写法

## Test plan

- [x] `npm run verify` 222/222 绿（新增 3 条 #71 测试）
- [x] GraphRAG 冒烟 EXIT=0，无 soft-gate，`波音 747（Boeing 747）` 正确出现
- [x] #66 / #68 / #69 回归全绿

## 相关

- Issue #71
- 同家族先前修复：#57 / #58 / #61 / #63
- 复用模板：#68 paragraph_match 注入 / #69 getDraftContractViolation