### PR TITLE
fix: tighten raw ** leak check to draft > source (#77)

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -6288,16 +6288,17 @@ function getDraftContractViolation(source: string, text: string): string | null 
     return source.trim() ? "draft returned empty content" : null;
   }
 
-  // Issue #69 (B): reject repair output that emits raw `**` markers when the
-  // protected source had zero raw `**` (all bold spans are placeholder-tokenized
-  // as `@@MDZH_STRONG_EMPHASIS_NNNN@@`). Raw `**` leaking through means the LLM
-  // invented bold markup, which corrupts span boundaries downstream. Runs
-  // before block-kind checks because a single-line `**X**` otherwise triggers
-  // the heading misclassification branch first and hides the root cause.
+  // Issue #69/#77 (B): reject repair output whose raw `**` marker count
+  // exceeds the protected source's. Most bold spans are placeholder-tokenized
+  // as `@@MDZH_STRONG_EMPHASIS_NNNN@@`, so sourceBoldCount is usually 0; #77
+  // widened this from `source===0 && draft>0` to `draft>source` so cases
+  // where protectInlineStrongEmphasis left some `**` unprotected (standalone
+  // emphasis-only line escape, cross-line span, length over the 80-char cap)
+  // still trip when the LLM invents additional bold markup.
   const sourceBoldCount = (source.match(/\*\*/g) ?? []).length;
   const draftBoldCount = (trimmed.match(/\*\*/g) ?? []).length;
-  if (sourceBoldCount === 0 && draftBoldCount > 0) {
-    return `draft introduced raw bold markers (** x ${draftBoldCount}) not present in the protected source`;
+  if (draftBoldCount > sourceBoldCount) {
+    return `draft introduced raw bold markers (** x ${draftBoldCount} vs source ${sourceBoldCount}) beyond the protected source`;
   }
 
   const trimmedSource = source.trim();

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -1733,6 +1733,15 @@ test("getDraftContractViolation preserves raw bold markers when the source alrea
   assert.equal(violation, null);
 });
 
+test("getDraftContractViolation rejects extra raw bold markers when the source already had some (#77)", () => {
+  const violation = getDraftContractViolationForTest(
+    "这是**原文本身**带有的加粗片段",
+    "这是**译文**保留的**额外**加粗片段"
+  );
+  assert.ok(violation, "expected a violation string, got null");
+  assert.match(violation!, /introduced raw bold markers/);
+});
+
 test("buildRepairPromptContext injects first_mention_bilingual cut-piece guidance when must_fix quotes an English target (#71)", () => {
   const context = buildRepairPromptContextForTest(
     createMinimalChunkPromptContext(),


### PR DESCRIPTION
## 目的

解决 #77：PR #70 的 draft contract Check B 用 `sourceBoldCount === 0 && draftBoldCount > 0`，在 `protectInlineStrongEmphasis` 留下未保护 `**`（标题独占行豁免、跨行 span、长度超 80 字）时漏判，LLM 自造加粗仍能穿过。

## 改动

- `src/translate.ts`：Check B 放宽为 `draftBoldCount > sourceBoldCount`；错误文案同步更新。
- `test/translate.test.ts`：新增 1 条测试覆盖"source 已有 2×`**`，draft 多出 2×`**`"的反例；原 4 条 #69 测试继续通过。

## 验证

- `npm run verify` 226/226 全绿。

## 后续

此改动纯结构收紧，不解决 #76（Mixture-of-Experts 非产品概念的首现双语锚定），后者另行处理。