### PR TITLE
fix: reverse whitelist for non-product ML concepts (#76)

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -7225,7 +7225,8 @@ function buildRepairPromptContext(
       "如果 must_fix 同时点名多个英文目标，必须在各自的首现位置分别补齐；不要因为其中一个已经补过，就认为整段已经达标。",
       "产品专名豁免（#74）：如果被点名的英文是商品型号、硬件产品名、GPU/CPU/芯片/机型/工作站/主机/平台/SDK/框架/CLI 等产品或品牌专名——例如 Mac Studio、DGX Spark、CUDA、RTX、Mixtral、Llama、GeForce、Quadro、Tesla、EPYC、Threadripper、Ryzen、Xeon、Arc、Blackwell、Hopper、Ada、Grace、H100、A100、L40S 等——中文技术圈默认直接使用英文原名，不需要补中文锚定；此时在译文里保留原英文专名即视为已达标。",
       "类目词黑名单：即使 must_fix 坚持要为产品专名补中文，也绝不能用“类别词”去充当中文译名——以下词一律禁止作为括注内容：机型、工作站、桌面机、台式机、主机、平台、系统、芯片、显卡、GPU、CPU、处理器、加速器、服务器、框架、工具、软件、SDK、CLI、品牌、公司、制造商、厂商、产品、设备、机器。这类类目词只会让专名变成“产品名（类目）”的机械结构，侮辱读者智商。",
-      "产品专名如果确实有广泛流通的中文官方译名（例如 Nvidia→英伟达、Apple→苹果、Intel→英特尔、AMD→超威），才允许补“中文官方译名（English）”；没有官方译名就保留英文原名本身。严禁把整行专名（如“Mac Studio M3 Ultra”）的 protected token 切开插入括注——这会直接触发 protected_span_integrity 硬失败。"
+      "产品专名如果确实有广泛流通的中文官方译名（例如 Nvidia→英伟达、Apple→苹果、Intel→英特尔、AMD→超威），才允许补“中文官方译名（English）”；没有官方译名就保留英文原名本身。严禁把整行专名（如“Mac Studio M3 Ultra”）的 protected token 切开插入括注——这会直接触发 protected_span_integrity 硬失败。",
+      "反向白名单（#76，必须补中文锚定的通用技术/学术概念）：以下这类词不是产品专名，属于机器学习 / 大模型 / 软件工程的通用概念，即使含连字符、PascalCase 或缩写形态，也必须按切片 A/B 补“中文译名（English）”，不能套用产品专名豁免。参考映射：Mixture-of-Experts → 混合专家（Mixture-of-Experts）、Retrieval-Augmented Generation / RAG → 检索增强生成（Retrieval-Augmented Generation, RAG）、Chain-of-Thought / CoT → 思维链（Chain-of-Thought, CoT）、Attention → 注意力（Attention）、Transformer → Transformer（保留英文原名，中文圈默认不译）、Fine-tuning → 微调（Fine-tuning）、Embedding → 嵌入（Embedding）、Quantization → 量化（Quantization）、Inference → 推理（Inference）、Tokenizer → 分词器（Tokenizer）、Prompt → 提示词（Prompt）。判别标准：如果该词在学术论文或中文技术圈已有稳定译名，就属于这一类，产品豁免不适用。"
     );
   }
 

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -1851,6 +1851,22 @@ test("buildRepairPromptContext does not emit product-noun exemption when no firs
   assert.doesNotMatch(notes, /类目词黑名单/);
 });
 
+test("buildRepairPromptContext emits reverse whitelist for non-product technical concepts (#76)", () => {
+  const context = buildRepairPromptContextForTest(
+    createMinimalChunkPromptContext(),
+    [
+      "第 7 个段落首次出现的 Mixture-of-Experts 需补齐中英对照，不能只写英文原名。"
+    ]
+  );
+
+  const notes = context.specialNotes.join("\n");
+  assert.match(notes, /反向白名单（#76/);
+  assert.match(notes, /Mixture-of-Experts → 混合专家/);
+  assert.match(notes, /Retrieval-Augmented Generation/);
+  assert.match(notes, /Chain-of-Thought/);
+  assert.match(notes, /产品豁免不适用/);
+});
+
 test("translateMarkdownArticle surfaces IR targets in repair guidance when pending repairs are already bound", () => {
   const context = buildRepairPromptContextForTest(
     createMinimalChunkPromptContext({


### PR DESCRIPTION
## 目的

解决 #76：PR #72（#71）注入的切片 A/B 配方对 Mixture-of-Experts 等通用概念无效，硬件文章 Chunk 2 segment 2 两轮 repair 都完成不了双语锚定。候选根因：#74 产品专名豁免被 LLM 误读为"Mixture-of-Experts 含连字符 + PascalCase → 像产品名 → 不需要锚"。

## 改动

- `src/translate.ts`：在 `firstMentionBilingualTargets` 注入块末尾新增一条"反向白名单（#76）"，列出 Mixture-of-Experts、RAG、CoT、Attention、Transformer、Fine-tuning、Embedding、Quantization、Inference、Tokenizer、Prompt 等 ML/软件工程通用概念并给出参考中文译名，明确产品豁免不适用。
- `test/translate.test.ts`：新增 1 条测试，用 Mixture-of-Experts 触发 first_mention_bilingual，校验注入包含反向白名单与参考译名。

## 验证

- `npm run verify` 全绿（226 tests, +1 new）。
- 端到端需要 LLM 实际运行硬件文章冒烟才能验证修复是否生效，建议合入后跑一次。

## 局限

本 PR 只走"方向 B（负向反例澄清）"。若 LLM 在真实冒烟中仍被豁免条款误导，后续再补"方向 C（draft contract 强制检测 must_fix 命名英文目标附近仍缺中文邻字时再拒绝）"。