### PR TITLE
chore: first_mention_bilingual 降级为 soft check (#80)

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -1129,9 +1129,24 @@ function parseAnchorCatalog(text: string): AnchorCatalog {
   return { anchors, headingPlans, emphasisPlans, blockPlans, aliasPlans, entityDisambiguationPlans, ignoredTerms };
 }
 
+// Issue #80: first_mention_bilingual 是语义判断而非结构断言。audit 与 draft
+// 两个 LLM 对"首现中英对照是否已经建立"经常产生主观分歧，gpt-5.5 等更强模型
+// 反而让 audit 更严格，repair cycle 的 2 轮无法收敛。把它列为 soft check：
+// 仍保留在 audit schema 里作为诊断信号 + repair prompt 里作为线索，但不再
+// 让它单独决定 isHardPass —— 这样只要 first_mention_bilingual 单独失败就不
+// 再触发 repair loop、不再被计入 soft-gate 告警、不再走 fallback 路径。
+const SEMANTIC_SOFT_CHECKS: readonly AuditCheckKey[] = ["first_mention_bilingual"];
+
 function isHardPass(audit: GateAudit): boolean {
-  return Object.values(audit.hard_checks).every((item) => item.pass);
+  return (Object.keys(audit.hard_checks) as AuditCheckKey[]).every((key) => {
+    if (SEMANTIC_SOFT_CHECKS.includes(key)) {
+      return true;
+    }
+    return audit.hard_checks[key].pass;
+  });
 }
+
+export { isHardPass as __testOnlyIsHardPass };
 
 function isBundledHardPass(audit: BundledGateAudit): boolean {
   return audit.segments.every((segment) => isHardPass(segment));

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -12,6 +12,7 @@ import {
   getDraftContractViolationForTest,
   parseGateAudit,
   translateMarkdownArticle,
+  __testOnlyIsHardPass,
   type ChunkPromptContext,
   type GateAudit
 } from "../src/translate.js";
@@ -552,7 +553,11 @@ test("translateMarkdownArticle reifies chunk failures into executable repair tas
             paragraph_match: { pass: true, problem: "" },
             first_mention_bilingual: { pass: false, problem: "第 1 个项目符号中的 npm registry 需补成 npm 注册表（npm registry）。" },
             numbers_units_logic: { pass: true, problem: "" },
-            chinese_punctuation: { pass: true, problem: "" },
+            // #80: first_mention_bilingual is a soft check and can't trigger
+            // the repair-task reification path on its own. Pair it with a
+            // non-structural hard failure so the reification + HardGateError
+            // path still exercises.
+            chinese_punctuation: { pass: false, problem: "第 1 个项目符号句末缺少中文标点。" },
             unit_conversion_boundary: { pass: true, problem: "" },
             protected_span_integrity: { pass: true, problem: "" }
           }),
@@ -1787,14 +1792,21 @@ test("buildRepairPromptContext does not emit first_mention_bilingual guidance fo
 test("translateMarkdownArticle ships first_mention_bilingual cut-piece guidance to the live repair prompt (#71 constructive smoke)", async () => {
   const source = "# Boeing Test\n\nThe Boeing 747 is a large aircraft.\n";
   const capturedPrompts: string[] = [];
+  // #80: first_mention_bilingual is now a soft check and can't trigger the
+  // repair loop by itself. Pair it with a non-structural hard failure
+  // (chinese_punctuation) so the repair loop still runs and we can verify
+  // first_mention_bilingual guidance is merged into the repair prompt.
   const failingAudit = createAudit(
     false,
-    ["第 1 段中\"Boeing 747\"首次出现未按要求补中英文对照，需在该处直接补齐。"],
+    [
+      "第 1 段中\"Boeing 747\"首次出现未按要求补中英文对照，需在该处直接补齐。",
+      "第 1 段句末中文标点缺失。"
+    ],
     {
       paragraph_match: { pass: true, problem: "" },
       first_mention_bilingual: { pass: false, problem: "Boeing 747 missing bilingual anchor" },
       numbers_units_logic: { pass: true, problem: "" },
-      chinese_punctuation: { pass: true, problem: "" },
+      chinese_punctuation: { pass: false, problem: "missing Chinese punctuation" },
       unit_conversion_boundary: { pass: true, problem: "" },
       protected_span_integrity: { pass: true, problem: "" }
     }
@@ -1874,6 +1886,36 @@ test("buildRepairPromptContext emits reverse whitelist for non-product technical
   assert.match(notes, /Retrieval-Augmented Generation/);
   assert.match(notes, /Chain-of-Thought/);
   assert.match(notes, /产品豁免不适用/);
+});
+
+test("isHardPass treats first_mention_bilingual as soft check and returns true when only it fails (#80)", () => {
+  const audit = createAudit(true);
+  audit.hard_checks.first_mention_bilingual = {
+    pass: false,
+    problem: "首段 Mixture-of-Experts 未建立中英对照。"
+  };
+  assert.equal(__testOnlyIsHardPass(audit), true);
+});
+
+test("isHardPass still returns false when a structural hard check fails alongside first_mention_bilingual (#80)", () => {
+  const audit = createAudit(true);
+  audit.hard_checks.first_mention_bilingual = { pass: false, problem: "缺首现对照" };
+  audit.hard_checks.paragraph_match = { pass: false, problem: "段落数量不一致" };
+  assert.equal(__testOnlyIsHardPass(audit), false);
+});
+
+test("isHardPass still returns false when a non-semantic hard check fails on its own (#80)", () => {
+  const audit = createAudit(true);
+  audit.hard_checks.protected_span_integrity = {
+    pass: false,
+    problem: "占位符 @@MDZH_STRONG_EMPHASIS_0001@@ 未恢复。"
+  };
+  assert.equal(__testOnlyIsHardPass(audit), false);
+});
+
+test("isHardPass returns true for all-pass audits regardless of semantic check bypass (#80)", () => {
+  const audit = createAudit(true);
+  assert.equal(__testOnlyIsHardPass(audit), true);
 });
 
 test("translateMarkdownArticle surfaces IR targets in repair guidance when pending repairs are already bound", () => {
@@ -3090,9 +3132,13 @@ test("translateMarkdownArticle fails after two repair cycles when the gate never
   );
 });
 
-test("translateMarkdownArticle under soft-gate emits degraded body and banner when only semantic hard-checks fail", async () => {
+test("translateMarkdownArticle under soft-gate treats first_mention_bilingual-only failures as a clean pass (#80)", async () => {
   const source = "# Title\n\nBody\n";
   const progress: string[] = [];
+  // #80: when only first_mention_bilingual fails (audit flags a judgment-call
+  // anchor miss but every structural/punctuation/unit check passes), the new
+  // contract is to treat this as a hard pass — no repair loop, no soft-gate
+  // fallback banner, no "Output is degraded" warning.
   const semanticFailingAudit = createAudit(false, ["正文首现术语缺少中英对照"], {
     paragraph_match: { pass: true, problem: "" },
     first_mention_bilingual: { pass: false, problem: "missing bilingual term" },
@@ -3117,16 +3163,18 @@ test("translateMarkdownArticle under soft-gate emits degraded body and banner wh
     onProgress: (message) => progress.push(message)
   });
 
-  assert.ok(result.markdown.length > 0, "soft-gate should emit a non-empty degraded body");
+  assert.ok(result.markdown.length > 0, "should emit a translated body");
   assert.ok(
-    progress.some((message) =>
-      /soft-gate enabled \(semantic failures only\)/.test(message)
-    ),
-    "expected per-chunk soft-gate log line"
+    !progress.some((message) => /soft-gate enabled \(semantic failures only\)/.test(message)),
+    "no per-chunk soft-gate log line should fire when only first_mention_bilingual fails"
   );
   assert.ok(
-    progress.some((message) => /Soft-gate fallback applied to \d+ chunk/.test(message)),
-    "expected final aggregate banner"
+    !progress.some((message) => /Soft-gate fallback applied to \d+ chunk/.test(message)),
+    "no aggregate degraded-output banner should fire under #80 contract"
+  );
+  assert.ok(
+    !progress.some((message) => /failed after \d+ repair cycle/.test(message)),
+    "first_mention_bilingual-only failures should not enter the repair loop"
   );
 });
 


### PR DESCRIPTION
## 目的

关闭 issue #80。把 \`first_mention_bilingual\` 从 hard check 列表摘出来：不再单独决定 \`isHardPass\`、不再触发 repair loop、不再落 soft-gate fallback。

## 背景

#66（默认软门）+ #71/#72/#74/#75/#76/#79（repair prompt 多轮优化）落地后，硬件文章冒烟仍然 3-4/4 chunk 走到 soft-gate fallback：audit 与 draft 两个 LLM 对"首现中英对照是否建立"常产生主观分歧；升级到 gpt-5.5 后 audit 更严格，4/4 全部 fallback。

结论：\`first_mention_bilingual\` 属于**语义判断**，不是**结构断言**。只有 \`paragraph_match\` / \`protected_span_integrity\` 机械可判定，其他语义判断题不应卡住流水线。

## 变更

1. 新增 \`SEMANTIC_SOFT_CHECKS: readonly AuditCheckKey[] = [\"first_mention_bilingual\"]\`
2. 修改 \`isHardPass\` 跳过该数组里的键
3. 在 audit schema / repair prompt 里保留 \`first_mention_bilingual\` 作为诊断信号（其他 hard check 失败触发的 repair loop 里顺便修首现对照）
4. 导出 \`__testOnlyIsHardPass\` 便于单测
5. 新增 4 条 #80 单测，更新 3 条既有测试以匹配新契约：
   - \`#71 constructive smoke\`：改用 \`chinese_punctuation\` 触发 repair loop，仍断言 #71 cut-piece guidance 注入 repair prompt
   - \`soft-gate semantic-only\` 测试：改名为 \`#80 clean pass\`，断言**无** soft-gate 告警、**无** repair cycle、**无** degraded 警示
   - \`reify-tasks\` 测试：搭配 \`chinese_punctuation\` 失败触发 reify 路径

## 验证

### 单元测试

\`\`\`
npm run verify
\`\`\`

231/231 passing。

### 端到端冒烟

硬件文章：

\`\`\`
node dist/src/cli.js --input index.md --output index-zh-80.md
\`\`\`

| 对比 | chunk 1 | chunk 2 | chunk 3 | chunk 4 |
| --- | --- | --- | --- | --- |
| 改前（pre-#80） | soft-gate | soft-gate | soft-gate | soft-gate |
| 改后（post-#80） | clean | clean | clean | **真实 paragraph_match 失败** |

改后 chunk 1-3 干净出稿、无 \"Output is degraded\" 告警。chunk 4 上的 \`paragraph_match\` 失败是 LLM draft 丢掉了"Form factor and noise. / Software ecosystem."两个列表项，属于独立的 draft 完整性 bug（需另开 issue 修 segment 切分 / list-block draft），与 #80 无关。

## 后续 issue

硬件文章 chunk 4 draft 列表项丢失问题需单独跟进：LLM 在 \"Factor In Total Cost of Ownership\" 章节把 4 个列表项切成两个 segment，segment 2 / segment 4 都只生成了前 2 项，后 2 项缺失。不在 #80 范围。

## Out of Scope

- 不扩 \`protected_span_integrity\` / \`paragraph_match\` 的判定规则
- 不调 \`MAX_REPAIR_CYCLES\`
- 不动 repair prompt 模板
- chunk 4 list-block draft 完整性另立 issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)