### PR TITLE
fix: 拒绝 repair 把 protected-span 占位符挪到标题行 (#77)

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -6360,6 +6360,40 @@ function getDraftContractViolation(source: string, text: string): string | null 
     }
   }
 
+  // Issue #77: reject drafts that move a protected-span placeholder onto a
+  // heading line while the source places it in prose. After restoreMarkdownSpans,
+  // the placeholder becomes `**xxx**`, so a heading misplacement surfaces as
+  // "首段标题处出现多余 **" in the protected_span_integrity audit — a structural
+  // hard check that soft-gate cannot save. Reject at the draft contract so
+  // repair retries get another swing before the structural gate throws.
+  const headingLinePattern = /^\s*#{1,6}\s/u;
+  const sourceHeadingPlaceholders = new Set<string>();
+  const sourceNonHeadingPlaceholders = new Set<string>();
+  for (const line of source.split(/\r?\n/)) {
+    const isHeading = headingLinePattern.test(line);
+    for (const match of line.matchAll(placeholderPattern)) {
+      if (isHeading) {
+        sourceHeadingPlaceholders.add(match[0]);
+      } else {
+        sourceNonHeadingPlaceholders.add(match[0]);
+      }
+    }
+  }
+  for (const line of trimmed.split(/\r?\n/)) {
+    if (!headingLinePattern.test(line)) {
+      continue;
+    }
+    for (const match of line.matchAll(placeholderPattern)) {
+      const token = match[0];
+      if (sourceHeadingPlaceholders.has(token)) {
+        continue;
+      }
+      if (sourceNonHeadingPlaceholders.has(token)) {
+        return `draft moved protected-span placeholder ${token} onto a heading line (source places it in prose)`;
+      }
+    }
+  }
+
   // Catch the "lazy LLM" pattern where a list item is replaced by ellipsis
   // ("- ……" or "- ...") but the source list item is real content. The audit
   // catches this too but repairing from a missing item is harder than rejecting

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -1747,6 +1747,56 @@ test("getDraftContractViolation rejects extra raw bold markers when the source a
   assert.match(violation!, /introduced raw bold markers/);
 });
 
+test("getDraftContractViolation rejects moving a protected-span placeholder onto a heading line (#77)", () => {
+  const source = [
+    "### Large models (30-70B): three paths",
+    "",
+    "Once models exceed consumer GPU VRAM (32 GB), three options remain.",
+    "",
+    "@@MDZH_STRONG_EMPHASIS_0001@@ The RTX Pro 6000 Blackwell runs a 70B Q4 model."
+  ].join("\n");
+  const draft = [
+    "### 大型模型（30-70B）：三种路径 @@MDZH_STRONG_EMPHASIS_0001@@",
+    "",
+    "一旦模型超过消费级 GPU 显存（32 GB），仅剩三种选项。",
+    "",
+    "RTX Pro 6000 Blackwell 可在单卡上运行 70B Q4 模型。"
+  ].join("\n");
+  const violation = getDraftContractViolationForTest(source, draft);
+  assert.ok(violation, "expected a violation string, got null");
+  assert.match(violation!, /moved protected-span placeholder .* onto a heading line/);
+});
+
+test("getDraftContractViolation allows a protected-span placeholder that stays on its non-heading line (#77)", () => {
+  const source = [
+    "### Large models (30-70B): three paths",
+    "",
+    "@@MDZH_STRONG_EMPHASIS_0001@@ The RTX Pro 6000 Blackwell runs a 70B Q4 model."
+  ].join("\n");
+  const draft = [
+    "### 大型模型（30-70B）：三种路径",
+    "",
+    "@@MDZH_STRONG_EMPHASIS_0001@@ RTX Pro 6000 Blackwell 可运行 70B Q4 模型。"
+  ].join("\n");
+  const violation = getDraftContractViolationForTest(source, draft);
+  assert.equal(violation, null);
+});
+
+test("getDraftContractViolation allows a placeholder that the source already puts on a heading line (#77)", () => {
+  const source = [
+    "### 关于 @@MDZH_INLINE_MARKDOWN_LINK_0001@@ 的说明",
+    "",
+    "段落内容。"
+  ].join("\n");
+  const draft = [
+    "### @@MDZH_INLINE_MARKDOWN_LINK_0001@@ 相关说明",
+    "",
+    "段落内容。"
+  ].join("\n");
+  const violation = getDraftContractViolationForTest(source, draft);
+  assert.equal(violation, null);
+});
+
 test("buildRepairPromptContext injects first_mention_bilingual cut-piece guidance when must_fix quotes an English target (#71)", () => {
   const context = buildRepairPromptContextForTest(
     createMinimalChunkPromptContext(),


### PR DESCRIPTION
## 目的

补齐 #77 Chunk 3 `首段标题处出现多余 \"**\"` 漏检。PR #78 已收紧 Check B 到 `draftBoldCount > sourceBoldCount`，但仍有一条上游路径未覆盖：

源文 `**Small Language Models (SLMs)**` 经 `protectInlineStrongEmphasis` 替换为 `@@MDZH_STRONG_EMPHASIS_0001@@`（sourceBoldCount=0）。LLM 在 repair 输出里把该占位符挪到标题行；draft 同样只含占位符（draftBoldCount=0），Check B 放行。直到 `restoreMarkdownSpans` 把占位符还原成 `**xxx**`，标题行才出现裸 `**` 并在 `protected_span_integrity` 结构性硬检中炸出 `EXIT=4`。

## 改动范围

- `src/translate.ts:6362-6395`：在 `getDraftContractViolation` 末尾新增一条检查，扫描源文与 draft 的每一行，若某占位符在源文出现在非标题行、在 draft 出现在标题行，则返回违约字符串，触发 repair 循环的 stricter-prompt 重试。
- `test/translate.test.ts:1750-1801`：新增 3 条单测（1 正向 + 2 反向：同行保留不误判；源文本就把占位符放在标题行的合法场景不误判）。

## 验证

- `npm run verify`：234/234 全绿，build 成功
- 硬件文章冒烟复测：原 Chunk 3 `首段标题处出现多余 \"**\"` 未复现。本次 `EXIT=4` 由 Chunk 4 的 `paragraph_match`（列表项丢失 \"Require bandwidth in RFPs\" / \"Benchmark before buying\"）触发，属于另一个独立问题（#82 范围），与 #77 scope 无关。

## 后续

Chunk 4 列表项丢失单独跟踪（建议在 #82 里补冒烟证据）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)