### PR TITLE
fix: 拒绝 draft 丢失列表项 (#82)

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -6412,6 +6412,24 @@ function getDraftContractViolation(source: string, text: string): string | null 
     }
   }
 
+  // Issue #82: reject drafts that partially drop list items. paragraph_match
+  // catches this at audit, but it's a structural hard check that soft-gate
+  // can't save; by the time it fires, up to 2 repair cycles have been spent
+  // re-rolling the same shape. Reject earlier at the draft contract so draft
+  // retries (stricter prompt) and repair retries each get a swing on a targeted
+  // signal.
+  //
+  // Constraint: only fire when the draft kept SOME bullets but fewer than the
+  // source. A draft with zero bullets typically indicates a different failure
+  // (empty/mocked output, structured-output debris) already covered by earlier
+  // checks; firing here would create noise for legacy tests that mock the
+  // executor without simulating bullet preservation.
+  const sourceListItemCount = countListItemLines(source);
+  const draftListItemCount = countListItemLines(trimmed);
+  if (sourceListItemCount >= 2 && draftListItemCount > 0 && draftListItemCount < sourceListItemCount) {
+    return `draft dropped ${sourceListItemCount - draftListItemCount} list item(s) (source=${sourceListItemCount}, draft=${draftListItemCount})`;
+  }
+
   if (looksLikeStructuredOutputDebris(source, trimmed)) {
     return "draft returned structured-output debris instead of translated content";
   }
@@ -8263,6 +8281,20 @@ function isListLikeBlock(content: string): boolean {
   return content
     .split(/\r?\n/)
     .some((line) => /^(\s*)([-*+]|\d+\.)\s+/.test(line.trimStart()));
+}
+
+// Counts every line that begins with a top-level list marker. Protected-span
+// placeholders are inline tokens (never line-leading), so they don't inflate
+// the count. Used by getDraftContractViolation (#82) to catch drafts that
+// drop bullets before paragraph_match throws a structural hard-gate failure.
+function countListItemLines(body: string): number {
+  let count = 0;
+  for (const line of body.split(/\r?\n/)) {
+    if (/^ {0,3}(?:[-*+]|\d+[.)])\s+/.test(line)) {
+      count += 1;
+    }
+  }
+  return count;
 }
 
 function isToolNameExplanationLine(line: string): boolean {

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -1797,6 +1797,60 @@ test("getDraftContractViolation allows a placeholder that the source already put
   assert.equal(violation, null);
 });
 
+test("getDraftContractViolation rejects drafts that drop a list item (#82)", () => {
+  const source = [
+    "Bandwidth and capacity narrow the field. Three correction factors determine the final choice.",
+    "",
+    "- Energy consumption.",
+    "A Mac Studio M3 Ultra draws 250–300W under sustained AI inference load.",
+    "- Form factor and noise.",
+    "A Mac Studio or Strix Halo mini-PC operates silently on a desk.",
+    "- Software ecosystem.",
+    "The inference framework significantly influences real-world performance."
+  ].join("\n");
+  const draft = [
+    "带宽与容量先做筛选，最终选型由三项修正因素决定。",
+    "",
+    "- 能耗。",
+    "Mac Studio M3 Ultra 在持续 AI 推理负载下功耗为 250–300W。",
+    "- 外形因素与噪声。",
+    "Mac Studio 或 Strix Halo 迷你 PC 可在桌面上静音运行。"
+  ].join("\n");
+  const violation = getDraftContractViolationForTest(source, draft);
+  assert.ok(violation, "expected a violation when draft drops a bullet");
+  assert.match(violation!, /dropped \d+ list item/);
+});
+
+test("getDraftContractViolation allows drafts that preserve every list item (#82)", () => {
+  const source = [
+    "- Add bandwidth to specifications",
+    "Memory bandwidth belongs as its own line item.",
+    "- Require bandwidth in RFPs",
+    "One line in the template suffices.",
+    "- Benchmark before buying",
+    "Before investments above $25,000, benchmark one representative."
+  ].join("\n");
+  const draft = [
+    "- 把带宽列入规格书。",
+    "内存带宽应作为独立条目列出。",
+    "- 在 RFP 中要求标注带宽。",
+    "模板里加一行即可。",
+    "- 采购前先基准测试。",
+    "超过 $25,000 的投资前，先对每类架构做一次基准测试。"
+  ].join("\n");
+  const violation = getDraftContractViolationForTest(source, draft);
+  assert.equal(violation, null);
+});
+
+test("getDraftContractViolation does not flag drafts with more list items than source (#82)", () => {
+  // A draft that accidentally adds a bullet is a different failure mode; #82
+  // targets the dropped-bullet case specifically.
+  const source = "- Alpha\n- Beta";
+  const draft = "- 甲\n- 乙\n- 丙";
+  const violation = getDraftContractViolationForTest(source, draft);
+  assert.equal(violation, null);
+});
+
 test("buildRepairPromptContext injects first_mention_bilingual cut-piece guidance when must_fix quotes an English target (#71)", () => {
   const context = buildRepairPromptContextForTest(
     createMinimalChunkPromptContext(),


### PR DESCRIPTION
## 问题

硬件文章 smoke 跑不过（issue #82）：chunk 4/4 segment 2/4 的 LLM draft 把 Step 4/Step 5 里 3 条 bullet 合并成 2 条，`paragraph_match` 结构硬检查直接失败；两个 repair cycle 都在相同形状上空转，最终 `HardGateError` 退出 4。

## 根因

`paragraph_match` 属于 `STRUCTURAL_HARD_CHECKS`，soft-gate 无法兜底，落到 audit 才发现已经晚了两个 repair cycle；LLM 在当前 repair prompt 下稳定重复同样的 bullet 合并，只靠 audit 失败信号无法驱动其改写。

## 方案

在 `getDraftContractViolation` 里加一条 bullet 计数差检查：若 `sourceListItemCount >= 2 && draftListItemCount > 0 && draftListItemCount < sourceListItemCount`，立即返回违约字符串。

- draft 违约会触发既有的 stricter-prompt 重试通道（`src/translate.ts:5881`, `5899`, `5925`, `6658`），每次重试有机会产出完整列表。
- 只在 draft 保留部分 bullet 时触发，避免误伤 mock 执行器的 legacy 集成测试（mock 常返回空/源内容，会被更早的 `looksLikeStructuredOutputDebris` 等检查接住）。

## 变更

- `src/translate.ts:6415-6430`：`getDraftContractViolation` 新增 bullet 计数差检查。
- `src/translate.ts:8283-8296`：`countListItemLines` 辅助函数，置于 `isListLikeBlock` 之后。
- `test/translate.test.ts:1799-1851`：3 条单测覆盖正反向（drop bullet / preserve bullet / draft 多于 source）。

## 验证

- `npm run verify`：237/237 绿，构建成功。
- 硬件文章 smoke（`how-to-choose-hardware-for-local-llm-inference-163632d93dcb`）：soft-gate 兜底 4 个 chunk，语义失败由 `SEMANTIC_SOFT_CHECKS` 正常接管，`index-zh-new.md` 成功写入；不再出现 EXIT=4。

## 后续

LLM 在当前 prompt 下仍倾向合并相邻 bullet，draft-contract 拦截+重试是必要兜底但非充分。若后续观察到类似失败率高企，再考虑下一步增强 `INITIAL_TRANSLATION_PROMPT` 与 `REPAIR_PROMPT` 中的列表完整性条款（单独开 issue 评估）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)