### PR TITLE
feat: 引入翻译流水线 telemetry 基础设施

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,6 +69,11 @@ Standard streams:
   - stdout only contains the final translated Markdown, unless --help or --version is used.
   - stderr reports progress, diagnostics, and failures.
 
+Telemetry:
+  - Set MDZH_TELEMETRY_PATH=<path> to emit JSONL run/chunk/stage/repair/gate events
+    to that file. Path is resolved relative to the working directory. One line per
+    event; useful for offline analysis of latency, token usage, and repair behavior.
+
 Exit codes:
   0  Success (may include soft-gate degraded output; see stderr for warnings).
   2  Invalid arguments or missing input.

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,0 +1,142 @@
+import { appendFile, mkdir } from "node:fs/promises";
+import path from "node:path";
+
+export type TelemetryEventType =
+  | "run.start"
+  | "run.end"
+  | "stage.start"
+  | "stage.end"
+  | "stage.error"
+  | "chunk.start"
+  | "chunk.end"
+  | "chunk.error"
+  | "repair.cycle"
+  | "gate.result"
+  | "analysis.shard.start"
+  | "analysis.shard.end";
+
+export type TelemetryEvent = {
+  ts: number;
+  runId: string;
+  type: TelemetryEventType;
+  stage?: string;
+  chunkId?: string;
+  cycle?: number;
+  durationMs?: number;
+  inputTokens?: number;
+  cachedInputTokens?: number;
+  outputTokens?: number;
+  error?: string;
+  meta?: Record<string, unknown>;
+};
+
+export interface TelemetrySink {
+  emit(event: TelemetryEvent): void;
+  close(): Promise<void>;
+}
+
+export const noopTelemetry: TelemetrySink = {
+  emit() {
+    // no-op
+  },
+  async close() {
+    // no-op
+  }
+};
+
+export function generateRunId(): string {
+  const ts = Date.now().toString(36);
+  const rand = Math.random().toString(36).slice(2, 8);
+  return `run_${ts}_${rand}`;
+}
+
+export function createMemoryTelemetrySink(): TelemetrySink & {
+  readonly events: readonly TelemetryEvent[];
+} {
+  const events: TelemetryEvent[] = [];
+  return {
+    get events(): readonly TelemetryEvent[] {
+      return events;
+    },
+    emit(event) {
+      events.push(event);
+    },
+    async close() {
+      // no-op
+    }
+  };
+}
+
+export function createJsonlTelemetrySink(filePath: string): TelemetrySink {
+  const buffer: TelemetryEvent[] = [];
+  let flushPromise: Promise<void> | null = null;
+  let dirEnsured = false;
+
+  async function ensureDir(): Promise<void> {
+    if (dirEnsured) {
+      return;
+    }
+    await mkdir(path.dirname(filePath), { recursive: true });
+    dirEnsured = true;
+  }
+
+  async function flush(): Promise<void> {
+    if (buffer.length === 0) {
+      return;
+    }
+    await ensureDir();
+    const lines = buffer.splice(0, buffer.length).map((event) => `${JSON.stringify(event)}\n`).join("");
+    await appendFile(filePath, lines, "utf8");
+  }
+
+  function scheduleFlush(): void {
+    if (flushPromise) {
+      return;
+    }
+    flushPromise = (async () => {
+      try {
+        // Allow more events to coalesce before writing.
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        await flush();
+      } finally {
+        flushPromise = null;
+        if (buffer.length > 0) {
+          scheduleFlush();
+        }
+      }
+    })();
+  }
+
+  return {
+    emit(event) {
+      buffer.push(event);
+      scheduleFlush();
+    },
+    async close() {
+      while (flushPromise) {
+        await flushPromise;
+      }
+      await flush();
+    }
+  };
+}
+
+export function combineTelemetrySinks(...sinks: TelemetrySink[]): TelemetrySink {
+  const active = sinks.filter((sink) => sink !== noopTelemetry);
+  if (active.length === 0) {
+    return noopTelemetry;
+  }
+  if (active.length === 1) {
+    return active[0]!;
+  }
+  return {
+    emit(event) {
+      for (const sink of active) {
+        sink.emit(event);
+      }
+    },
+    async close() {
+      await Promise.all(active.map((sink) => sink.close()));
+    }
+  };
+}

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -29,6 +29,12 @@ import {
 } from "./anchor-normalization.js";
 import { CodexExecutionError, FormattingError, HardGateError } from "./errors.js";
 import { formatTranslatedBody, reconstructMarkdown } from "./format.js";
+import {
+  createJsonlTelemetrySink,
+  generateRunId,
+  noopTelemetry,
+  type TelemetrySink
+} from "./telemetry.js";
 import { planMarkdownChunks, type MarkdownChunk, type MarkdownChunkPlan } from "./markdown-chunks.js";
 import {
   extractTranslatableStrongEmphasisSpans,
@@ -200,6 +206,13 @@ export type TranslateOptions = {
    * that defer final acceptance to the independent quality checker.
    */
   softGate?: boolean;
+  /**
+   * Optional telemetry sink. When provided, the run emits structured events
+   * (`run.*`, `chunk.*`, `stage.*`, `repair.cycle`, `gate.result`) for
+   * downstream observability. Defaults to a no-op sink so callers that don't
+   * care pay nothing.
+   */
+  telemetry?: TelemetrySink;
 };
 
 export type TranslateResult = {
@@ -1201,6 +1214,10 @@ async function executeStageWithTimeout(
     timeoutMs: number;
     heartbeatLabel: string;
     onHeartbeat?: (message: string) => void;
+    telemetry?: TelemetrySink;
+    runId?: string;
+    chunkId?: string;
+    extra?: Record<string, unknown>;
   }
 ): Promise<CodexExecResult> {
   const heartbeatMs = getExecutionHeartbeatMs();
@@ -1214,12 +1231,56 @@ async function executeStageWithTimeout(
     report(meta.options, meta.stage, message);
   }, heartbeatMs);
 
+  const sink = meta.telemetry ?? meta.options.telemetry ?? noopTelemetry;
+  const runId = meta.runId ?? "run_anonymous";
+  const baseMeta: Record<string, unknown> = {
+    label: meta.heartbeatLabel,
+    model: execOptions.model,
+    promptChars: prompt.length,
+    ...meta.extra
+  };
+
+  const chunkIdField = meta.chunkId !== undefined ? { chunkId: meta.chunkId } : {};
+
+  sink.emit({
+    ts: startedAt,
+    runId,
+    type: "stage.start",
+    stage: meta.stage,
+    ...chunkIdField,
+    meta: baseMeta
+  });
+
   try {
-    return await executor.execute(prompt, {
+    const result = await executor.execute(prompt, {
       ...execOptions,
       timeoutMs: meta.timeoutMs
     });
+    sink.emit({
+      ts: Date.now(),
+      runId,
+      type: "stage.end",
+      stage: meta.stage,
+      ...chunkIdField,
+      durationMs: Date.now() - startedAt,
+      inputTokens: result.usage.inputTokens,
+      cachedInputTokens: result.usage.cachedInputTokens,
+      outputTokens: result.usage.outputTokens,
+      meta: baseMeta
+    });
+    return result;
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    sink.emit({
+      ts: Date.now(),
+      runId,
+      type: "stage.error",
+      stage: meta.stage,
+      ...chunkIdField,
+      durationMs: Date.now() - startedAt,
+      error: message,
+      meta: baseMeta
+    });
     if (error instanceof CodexExecutionError && /timed out after \d+ms\./i.test(error.message)) {
       throw new CodexExecutionError(`${meta.heartbeatLabel} timed out after ${meta.timeoutMs}ms.`);
     }
@@ -2104,7 +2165,7 @@ function isAnalysisShardTimeoutError(error: unknown): boolean {
 
 async function executeAnalysisShardAttempt(
   state: TranslationRunState,
-  context: Pick<ChunkTranslationContext, "executor" | "postDraftModel" | "cwd" | "options" | "postDraftReasoningEffort">,
+  context: Pick<ChunkTranslationContext, "executor" | "postDraftModel" | "cwd" | "options" | "postDraftReasoningEffort" | "runId" | "telemetry">,
   formalCatalog: AnchorCatalog,
   accumulatedCatalog: AnchorCatalog,
   shard: AnalysisShard,
@@ -2136,6 +2197,25 @@ async function executeAnalysisShardAttempt(
     );
   }, heartbeatMs);
 
+  const shardMeta = {
+    shardIndex: shard.index + 1,
+    shardCount,
+    attempt,
+    chunkCount: shard.chunkIds.length,
+    sourceChars: shard.sourceChars,
+    headingCount: shard.headingCount,
+    emphasisCount: shard.emphasisCount,
+    timeoutMs,
+    promptChars: prompt.length
+  };
+  context.telemetry.emit({
+    ts: shardStartedAt,
+    runId: context.runId,
+    type: "analysis.shard.start",
+    stage: "analyze",
+    meta: shardMeta
+  });
+
   try {
     const result = await context.executor.execute(prompt, {
       cwd: context.cwd,
@@ -2152,12 +2232,39 @@ async function executeAnalysisShardAttempt(
       }
     });
     const normalizedShardCatalog = normalizeDiscoveredAnchorCatalog(state, parseAnchorCatalog(result.text));
+    context.telemetry.emit({
+      ts: Date.now(),
+      runId: context.runId,
+      type: "analysis.shard.end",
+      stage: "analyze",
+      durationMs: Date.now() - shardStartedAt,
+      inputTokens: result.usage.inputTokens,
+      cachedInputTokens: result.usage.cachedInputTokens,
+      outputTokens: result.usage.outputTokens,
+      meta: {
+        ...shardMeta,
+        anchorCount: normalizedShardCatalog.anchors.length,
+        headingPlanCount: normalizedShardCatalog.headingPlans?.length ?? 0,
+        ignoredTermCount: normalizedShardCatalog.ignoredTerms.length
+      }
+    });
     report(
       context.options,
       "analyze",
       `Shard ${shard.index + 1}/${shardCount} attempt ${attempt} finished: ${normalizedShardCatalog.anchors.length} anchors, ${normalizedShardCatalog.headingPlans?.length ?? 0} heading plan(s), ${normalizedShardCatalog.ignoredTerms.length} ignored term(s).`
     );
     return normalizedShardCatalog;
+  } catch (error) {
+    context.telemetry.emit({
+      ts: Date.now(),
+      runId: context.runId,
+      type: "analysis.shard.end",
+      stage: "analyze",
+      durationMs: Date.now() - shardStartedAt,
+      error: error instanceof Error ? error.message : String(error),
+      meta: shardMeta
+    });
+    throw error;
   } finally {
     clearInterval(heartbeat);
   }
@@ -2165,7 +2272,7 @@ async function executeAnalysisShardAttempt(
 
 async function recoverHeadingPlansOnly(
   state: TranslationRunState,
-  context: Pick<ChunkTranslationContext, "executor" | "postDraftModel" | "cwd" | "options" | "postDraftReasoningEffort">,
+  context: Pick<ChunkTranslationContext, "executor" | "postDraftModel" | "cwd" | "options" | "postDraftReasoningEffort" | "runId" | "telemetry">,
   catalog: AnchorCatalog
 ): Promise<AnchorCatalog> {
   const prompt = buildHeadingRecoveryAnalysisPrompt(buildHeadingRecoveryInput(state, catalog));
@@ -2214,7 +2321,7 @@ async function recoverHeadingPlansOnly(
 
 async function recoverEmphasisPlansOnly(
   state: TranslationRunState,
-  context: Pick<ChunkTranslationContext, "executor" | "postDraftModel" | "cwd" | "options" | "postDraftReasoningEffort">,
+  context: Pick<ChunkTranslationContext, "executor" | "postDraftModel" | "cwd" | "options" | "postDraftReasoningEffort" | "runId" | "telemetry">,
   catalog: AnchorCatalog
 ): Promise<AnchorCatalog> {
   const prompt = buildEmphasisRecoveryAnalysisPrompt(buildEmphasisRecoveryInput(state, catalog));
@@ -2263,7 +2370,7 @@ async function recoverEmphasisPlansOnly(
 
 async function analyzeShardWithFallback(
   state: TranslationRunState,
-  context: Pick<ChunkTranslationContext, "executor" | "postDraftModel" | "cwd" | "options" | "postDraftReasoningEffort">,
+  context: Pick<ChunkTranslationContext, "executor" | "postDraftModel" | "cwd" | "options" | "postDraftReasoningEffort" | "runId" | "telemetry">,
   formalCatalog: AnchorCatalog,
   accumulatedCatalog: AnchorCatalog,
   shard: AnalysisShard,
@@ -2360,7 +2467,7 @@ async function analyzeShardWithFallback(
 
 async function analyzeDocumentForAnchors(
   state: TranslationRunState,
-  context: Pick<ChunkTranslationContext, "executor" | "postDraftModel" | "cwd" | "options" | "postDraftReasoningEffort">
+  context: Pick<ChunkTranslationContext, "executor" | "postDraftModel" | "cwd" | "options" | "postDraftReasoningEffort" | "runId" | "telemetry">
 ): Promise<AnchorCatalog> {
   report(context.options, "analyze", "Loading formal known_entities.");
   const knownEntities = loadKnownEntities();
@@ -2523,6 +2630,37 @@ export async function translateMarkdownArticle(source: string, options: Translat
     : undefined;
   const cwd = options.cwd ?? process.cwd();
   const sourcePathHint = options.sourcePathHint ?? "article.md";
+  // Sink resolution order:
+  // 1. options.telemetry (caller-owned; the caller closes it).
+  // 2. MDZH_TELEMETRY_PATH env var → JSONL sink the run owns and closes itself.
+  // 3. noop sink.
+  let ownedTelemetry: TelemetrySink | null = null;
+  let telemetry: TelemetrySink;
+  if (options.telemetry) {
+    telemetry = options.telemetry;
+  } else if (process.env.MDZH_TELEMETRY_PATH?.trim()) {
+    ownedTelemetry = createJsonlTelemetrySink(
+      path.resolve(cwd, process.env.MDZH_TELEMETRY_PATH.trim())
+    );
+    telemetry = ownedTelemetry;
+  } else {
+    telemetry = noopTelemetry;
+  }
+  const runId = generateRunId();
+  const runStartedAt = Date.now();
+  telemetry.emit({
+    ts: runStartedAt,
+    runId,
+    type: "run.start",
+    meta: {
+      sourcePathHint,
+      sourceChars: source.length,
+      draftModel,
+      postDraftModel,
+      styleMode,
+      softGate: Boolean(options.softGate)
+    }
+  });
   const { frontmatter, body } = extractFrontmatter(source);
   const { protectedBody, spans } = protectMarkdownSpans(body);
   const chunkPlan = planMarkdownChunks(protectedBody);
@@ -2557,7 +2695,9 @@ export async function translateMarkdownArticle(source: string, options: Translat
       postDraftModel,
       cwd,
       options,
-      postDraftReasoningEffort
+      postDraftReasoningEffort,
+      runId,
+      telemetry
     } as const;
     const analysisCacheDir = resolveAnalysisCacheDir(cwd, options);
     let anchorCatalog: AnchorCatalog | null = null;
@@ -2618,6 +2758,19 @@ export async function translateMarkdownArticle(source: string, options: Translat
         report(options, "draft", `Skipping ${chunkId}; restored from checkpoint.`);
         continue;
       }
+      const chunkStartedAt = Date.now();
+      telemetry.emit({
+        ts: chunkStartedAt,
+        runId,
+        type: "chunk.start",
+        chunkId,
+        meta: {
+          chunkIndex: chunk.index + 1,
+          chunkCount: chunkPlan.chunks.length,
+          headingPath: chunk.headingPath,
+          chunkChars: chunk.source.length
+        }
+      });
       let chunkResult;
       try {
         chunkResult = await translateProtectedChunk(chunk, chunkPlan, {
@@ -2632,7 +2785,9 @@ export async function translateMarkdownArticle(source: string, options: Translat
           spanIndex,
           nextLocalSpanIndex,
           draftReasoningEffort: DRAFT_REASONING_EFFORT as ReasoningEffort,
-          postDraftReasoningEffort
+          postDraftReasoningEffort,
+          runId,
+          telemetry
         });
       } catch (error) {
         // Soft-gate fallback for any chunk-level error (HardGateError from
@@ -2640,14 +2795,32 @@ export async function translateMarkdownArticle(source: string, options: Translat
         // protected source for this chunk so the final output.md has a
         // structurally complete document, just with the failed chunk left in
         // its English / partial form. Quality checker will surface this.
+        const errorMessage = error instanceof Error ? error.message : String(error);
         if (!options.softGate || isStructuralHardGateError(error)) {
+          telemetry.emit({
+            ts: Date.now(),
+            runId,
+            type: "chunk.error",
+            chunkId,
+            durationMs: Date.now() - chunkStartedAt,
+            error: errorMessage,
+            meta: { recovered: false, structural: isStructuralHardGateError(error) }
+          });
           throw error;
         }
-        const message = error instanceof Error ? error.message : String(error);
+        telemetry.emit({
+          ts: Date.now(),
+          runId,
+          type: "chunk.error",
+          chunkId,
+          durationMs: Date.now() - chunkStartedAt,
+          error: errorMessage,
+          meta: { recovered: true, structural: false }
+        });
         report(
           options,
           "audit",
-          `Chunk ${chunk.index + 1}/${chunkPlan.chunks.length} (${chunk.headingPath.join(" > ") || "untitled"}): soft-gate caught chunk failure (${message}); falling back to source content.`
+          `Chunk ${chunk.index + 1}/${chunkPlan.chunks.length} (${chunk.headingPath.join(" > ") || "untitled"}): soft-gate caught chunk failure (${errorMessage}); falling back to source content.`
         );
         // Pass only spans whose placeholder ID appears in this chunk's source
         // — restoreMarkdownSpans throws if asked to restore a span absent from
@@ -2658,10 +2831,22 @@ export async function translateMarkdownArticle(source: string, options: Translat
         chunkResult = {
           body: fallbackBody,
           repairCyclesUsed: 0,
-          gateAudit: createSyntheticChunkFailureAudit(message),
+          gateAudit: createSyntheticChunkFailureAudit(errorMessage),
           nextLocalSpanIndex
         };
       }
+
+      telemetry.emit({
+        ts: Date.now(),
+        runId,
+        type: "chunk.end",
+        chunkId,
+        durationMs: Date.now() - chunkStartedAt,
+        meta: {
+          repairCyclesUsed: chunkResult.repairCyclesUsed,
+          hardPass: isHardPass(chunkResult.gateAudit)
+        }
+      });
 
       restoredChunks.push(chunkResult.body + chunk.separatorAfter);
       gateAudits.push(chunkResult.gateAudit);
@@ -2692,7 +2877,9 @@ export async function translateMarkdownArticle(source: string, options: Translat
         model: postDraftModel,
         options,
         reasoningEffort: postDraftReasoningEffort,
-        sourceSpans: spans
+        sourceSpans: spans,
+        runId,
+        telemetry
       });
       translatedBody = finalStyleResult.body;
       styleApplied = finalStyleResult.styleApplied;
@@ -2721,7 +2908,7 @@ export async function translateMarkdownArticle(source: string, options: Translat
         );
       }
     }
-    return {
+    const result = {
       markdown,
       model: draftModel,
       repairCyclesUsed,
@@ -2729,8 +2916,36 @@ export async function translateMarkdownArticle(source: string, options: Translat
       gateAudit: mergeGateAudits(gateAudits),
       chunkCount: chunkPlan.chunks.length
     };
+    telemetry.emit({
+      ts: Date.now(),
+      runId,
+      type: "run.end",
+      durationMs: Date.now() - runStartedAt,
+      meta: {
+        chunkCount: result.chunkCount,
+        repairCyclesUsed,
+        styleApplied,
+        hardPass: isHardPass(result.gateAudit)
+      }
+    });
+    if (ownedTelemetry) {
+      await ownedTelemetry.close();
+    }
+    return result;
   } catch (error) {
     await writeDebugStateIfRequested(state);
+    const message = error instanceof Error ? error.message : String(error);
+    telemetry.emit({
+      ts: Date.now(),
+      runId,
+      type: "run.end",
+      durationMs: Date.now() - runStartedAt,
+      error: message,
+      meta: { failed: true }
+    });
+    if (ownedTelemetry) {
+      await ownedTelemetry.close();
+    }
     if (error instanceof HardGateError || error instanceof FormattingError) {
       throw error;
     }
@@ -2800,6 +3015,8 @@ type ChunkTranslationContext = {
   nextLocalSpanIndex: number;
   draftReasoningEffort: ReasoningEffort;
   postDraftReasoningEffort: ReasoningEffort | undefined;
+  runId: string;
+  telemetry: TelemetrySink;
 };
 
 type ChunkTranslationResult = {
@@ -4794,6 +5011,18 @@ async function translateProtectedChunk(
     chunkPromptContext,
     chunkLabel
   );
+  context.telemetry.emit({
+    ts: Date.now(),
+    runId: context.runId,
+    type: "gate.result",
+    chunkId: context.chunkId,
+    meta: {
+      stage: "initial",
+      hardPass: isBundledHardPass(bundledAudit),
+      failedSegments: bundledAudit.segments.filter((audit) => !isHardPass(audit)).length,
+      mustFixCount: bundledAudit.segments.reduce((sum, audit) => sum + audit.must_fix.length, 0)
+    }
+  });
 
   while (
     !isBundledHardPass(bundledAudit) &&
@@ -4802,6 +5031,18 @@ async function translateProtectedChunk(
   ) {
     repairCyclesUsed += 1;
     const failedSegmentCount = bundledAudit.segments.filter((audit) => !isHardPass(audit)).length;
+    context.telemetry.emit({
+      ts: Date.now(),
+      runId: context.runId,
+      type: "repair.cycle",
+      chunkId: context.chunkId,
+      cycle: repairCyclesUsed,
+      meta: {
+        maxCycles: MAX_REPAIR_CYCLES,
+        failedSegments: failedSegmentCount,
+        mustFixCount: bundledAudit.segments.reduce((sum, audit) => sum + audit.must_fix.length, 0)
+      }
+    });
     report(
       context.options,
       "repair",
@@ -4845,6 +5086,19 @@ async function translateProtectedChunk(
       chunkPromptContext,
       chunkLabel
     );
+    context.telemetry.emit({
+      ts: Date.now(),
+      runId: context.runId,
+      type: "gate.result",
+      chunkId: context.chunkId,
+      cycle: repairCyclesUsed,
+      meta: {
+        stage: "post-repair",
+        hardPass: isBundledHardPass(bundledAudit),
+        failedSegments: bundledAudit.segments.filter((audit) => !isHardPass(audit)).length,
+        mustFixCount: bundledAudit.segments.reduce((sum, audit) => sum + audit.must_fix.length, 0)
+      }
+    });
   }
 
   if (!isBundledHardPass(bundledAudit)) {
@@ -5086,6 +5340,8 @@ async function applyFinalStylePolish(
     options: TranslateOptions;
     reasoningEffort: ReasoningEffort | undefined;
     sourceSpans: readonly ProtectedSpan[];
+    runId: string;
+    telemetry: TelemetrySink;
   }
 ): Promise<{ body: string; styleApplied: boolean }> {
   const reprotectableSourceSpans = context.sourceSpans.filter((span) =>
@@ -5111,7 +5367,9 @@ async function applyFinalStylePolish(
         stage: "style",
         timeoutMs: getStyleTimeoutMs(),
         heartbeatLabel: "Final style polish",
-        onHeartbeat: (message) => report(context.options, "style", message)
+        onHeartbeat: (message) => report(context.options, "style", message),
+        telemetry: context.telemetry,
+        runId: context.runId
       }
     );
   } catch (error) {
@@ -5819,7 +6077,11 @@ async function translateProtectedSegment(
         timeoutMs: getDraftTimeoutMs(),
         heartbeatLabel: `Chunk ${chunkPromptContext.chunkIndex}/${plan.chunks.length}${chunkLabel}: draft`,
         onHeartbeat: (message) =>
-          report(context.options, "draft", message)
+          report(context.options, "draft", message),
+        telemetry: context.telemetry,
+        runId: context.runId,
+        chunkId: context.chunkId,
+        extra: { lane: "default" }
       }
     );
   const executeJsonBlockDraft = async (prompt: string, blockCount: number) =>
@@ -5841,7 +6103,11 @@ async function translateProtectedSegment(
         timeoutMs: getDraftTimeoutMs(),
         heartbeatLabel: `Chunk ${chunkPromptContext.chunkIndex}/${plan.chunks.length}${chunkLabel}: draft`,
         onHeartbeat: (message) =>
-          report(context.options, "draft", message)
+          report(context.options, "draft", message),
+        telemetry: context.telemetry,
+        runId: context.runId,
+        chunkId: context.chunkId,
+        extra: { lane: "json-blocks", blockCount }
       }
     );
 
@@ -6575,7 +6841,15 @@ async function repairDraftedSegment(
           stage: "repair",
           timeoutMs: getRepairTimeoutMs(),
           heartbeatLabel: `Chunk ${draftedSegment.promptContext.chunkIndex}/${plan.chunks.length}${chunkLabel}, segment ${draftedSegment.segment.index + 1}${batchSuffix}: repair`,
-          onHeartbeat: (message) => report(context.options, "repair", message)
+          onHeartbeat: (message) => report(context.options, "repair", message),
+          telemetry: context.telemetry,
+          runId: context.runId,
+          chunkId: context.chunkId,
+          extra: {
+            lane: "default",
+            segmentIndex: draftedSegment.segment.index + 1,
+            batch: `${batchIndex + 1}/${repairTaskBatches.length}`
+          }
         }
       );
     const executeJsonBlockRepair = async (prompt: string, blockCount: number) =>
@@ -6603,7 +6877,16 @@ async function repairDraftedSegment(
           stage: "repair",
           timeoutMs: getRepairTimeoutMs(),
           heartbeatLabel: `Chunk ${draftedSegment.promptContext.chunkIndex}/${plan.chunks.length}${chunkLabel}, segment ${draftedSegment.segment.index + 1}${batchSuffix}: repair`,
-          onHeartbeat: (message) => report(context.options, "repair", message)
+          onHeartbeat: (message) => report(context.options, "repair", message),
+          telemetry: context.telemetry,
+          runId: context.runId,
+          chunkId: context.chunkId,
+          extra: {
+            lane: "json-blocks",
+            blockCount,
+            segmentIndex: draftedSegment.segment.index + 1,
+            batch: `${batchIndex + 1}/${repairTaskBatches.length}`
+          }
         }
       );
 
@@ -7424,7 +7707,11 @@ async function runBundledGateAudit(
         stage: "audit",
         timeoutMs: getAuditTimeoutMs(),
         heartbeatLabel: `Chunk ${chunkPromptContext.chunkIndex}/${plan.chunks.length}${chunkLabel}: bundled audit`,
-        onHeartbeat: (message) => report(context.options, "audit", message)
+        onHeartbeat: (message) => report(context.options, "audit", message),
+        telemetry: context.telemetry,
+        runId: context.runId,
+        chunkId: context.chunkId,
+        extra: { lane: "bundled", segmentCount: segmentIndices.length }
       }
     );
   } catch (error) {
@@ -7579,7 +7866,14 @@ async function runFallbackSegmentAudits(
         stage: "audit",
         timeoutMs: getAuditTimeoutMs(),
         heartbeatLabel: `Chunk ${chunkPromptContext.chunkIndex}/${plan.chunks.length}${segmentLabel}: per-segment audit`,
-        onHeartbeat: (message) => report(context.options, "audit", message)
+        onHeartbeat: (message) => report(context.options, "audit", message),
+        telemetry: context.telemetry,
+        runId: context.runId,
+        chunkId: context.chunkId,
+        extra: {
+          lane: "per-segment",
+          segmentIndex: draftedSegment.segment.index + 1
+        }
       }
     );
 

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -1,0 +1,111 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  combineTelemetrySinks,
+  createJsonlTelemetrySink,
+  createMemoryTelemetrySink,
+  generateRunId,
+  noopTelemetry,
+  type TelemetryEvent
+} from "../src/telemetry.js";
+
+test("generateRunId returns stable-shaped identifiers", () => {
+  const a = generateRunId();
+  const b = generateRunId();
+  assert.match(a, /^run_[a-z0-9]+_[a-z0-9]+$/);
+  assert.match(b, /^run_[a-z0-9]+_[a-z0-9]+$/);
+  assert.notEqual(a, b);
+});
+
+test("noopTelemetry swallows events and closes cleanly", async () => {
+  noopTelemetry.emit({ ts: 1, runId: "r", type: "run.start" });
+  await noopTelemetry.close();
+});
+
+test("createMemoryTelemetrySink records emitted events in order", async () => {
+  const sink = createMemoryTelemetrySink();
+  sink.emit({ ts: 1, runId: "r", type: "run.start" });
+  sink.emit({ ts: 2, runId: "r", type: "stage.start", stage: "draft" });
+  sink.emit({ ts: 3, runId: "r", type: "stage.end", stage: "draft", durationMs: 10 });
+
+  const events = [...sink.events];
+  assert.equal(events.length, 3);
+  assert.deepEqual(
+    events.map((event) => event.type),
+    ["run.start", "stage.start", "stage.end"]
+  );
+  await sink.close();
+});
+
+test("createJsonlTelemetrySink writes one JSON object per line", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "telemetry-test-"));
+  try {
+    const filePath = path.join(dir, "nested", "events.jsonl");
+    const sink = createJsonlTelemetrySink(filePath);
+    const events: TelemetryEvent[] = [
+      { ts: 1, runId: "r", type: "run.start" },
+      { ts: 2, runId: "r", type: "stage.end", stage: "audit", durationMs: 5, inputTokens: 10, outputTokens: 4 },
+      { ts: 3, runId: "r", type: "run.end", durationMs: 100 }
+    ];
+    for (const event of events) {
+      sink.emit(event);
+    }
+    await sink.close();
+
+    const raw = await readFile(filePath, "utf8");
+    const lines = raw.split("\n").filter((line) => line.length > 0);
+    assert.equal(lines.length, 3);
+    const parsed = lines.map((line) => JSON.parse(line)) as TelemetryEvent[];
+    assert.deepEqual(parsed, events);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("createJsonlTelemetrySink coalesces rapid emits", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "telemetry-test-"));
+  try {
+    const filePath = path.join(dir, "events.jsonl");
+    const sink = createJsonlTelemetrySink(filePath);
+    for (let i = 0; i < 50; i += 1) {
+      sink.emit({ ts: i, runId: "r", type: "stage.start", stage: "draft" });
+    }
+    await sink.close();
+    const raw = await readFile(filePath, "utf8");
+    const lines = raw.split("\n").filter((line) => line.length > 0);
+    assert.equal(lines.length, 50);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("combineTelemetrySinks broadcasts to every active sink", async () => {
+  const a = createMemoryTelemetrySink();
+  const b = createMemoryTelemetrySink();
+  const combined = combineTelemetrySinks(a, b, noopTelemetry);
+  combined.emit({ ts: 1, runId: "r", type: "run.start" });
+  combined.emit({ ts: 2, runId: "r", type: "run.end", durationMs: 1 });
+  await combined.close();
+
+  assert.equal(a.events.length, 2);
+  assert.equal(b.events.length, 2);
+  assert.deepEqual(
+    [...a.events].map((event) => event.type),
+    ["run.start", "run.end"]
+  );
+});
+
+test("combineTelemetrySinks short-circuits when only noopTelemetry is provided", () => {
+  const sink = combineTelemetrySinks(noopTelemetry, noopTelemetry);
+  assert.equal(sink, noopTelemetry);
+});
+
+test("combineTelemetrySinks unwraps when only one active sink remains", () => {
+  const memory = createMemoryTelemetrySink();
+  const sink = combineTelemetrySinks(noopTelemetry, memory);
+  assert.equal(sink, memory);
+});

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../src/translate.js";
 import { CodexExecutionError } from "../src/errors.js";
 import type { CodexExecOptions, CodexExecResult, CodexExecutor } from "../src/codex-exec.js";
+import { createMemoryTelemetrySink, type TelemetryEvent } from "../src/telemetry.js";
 
 function isDocumentAnalysisPrompt(prompt: string): boolean {
   return prompt.includes("【文档分析输入】");
@@ -3313,5 +3314,107 @@ test("translateMarkdownArticle under soft-gate still throws HardGateError when a
       return true;
     }
   );
+});
+
+test("translateMarkdownArticle emits telemetry around run, chunks, stages and gate results", async () => {
+  const source = ["# Hello", "", "World."].join("\n");
+  const sink = createMemoryTelemetrySink();
+
+  const executor: CodexExecutor = {
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return {
+          ...createExecResult(createEmptyAnchorCatalog()),
+          usage: { inputTokens: 100, cachedInputTokens: 50, outputTokens: 20, totalTokens: 120 }
+        };
+      }
+      if (options.outputSchema && prompt.includes("### BLOCK")) {
+        const blockCount = (prompt.match(/^### BLOCK \d+ \([^)]+\)$/gm) ?? []).length || 1;
+        return {
+          ...createExecResult(JSON.stringify({ blocks: Array.from({ length: blockCount }, () => "你好世界") })),
+          usage: { inputTokens: 80, cachedInputTokens: 30, outputTokens: 12, totalTokens: 92 }
+        };
+      }
+      if (options.outputSchema || prompt.includes('"hard_checks"') || prompt.includes("只返回 JSON")) {
+        return {
+          ...createExecResult(wrapAuditForSegments(prompt, createAudit(true))),
+          usage: { inputTokens: 60, cachedInputTokens: 20, outputTokens: 30, totalTokens: 90 }
+        };
+      }
+      const current = extractPromptSection(prompt, "【当前译文】");
+      if (current !== null) {
+        return createExecResult(current);
+      }
+      return createExecResult("你好世界");
+    }
+  };
+
+  await translateMarkdownArticle(source, {
+    executor,
+    formatter: async (markdown) => markdown,
+    telemetry: sink
+  });
+
+  const events = [...sink.events];
+  const types = events.map((event) => event.type);
+
+  assert.equal(types[0], "run.start");
+  assert.equal(types[types.length - 1], "run.end");
+  assert.ok(types.includes("chunk.start"), "expected chunk.start");
+  assert.ok(types.includes("chunk.end"), "expected chunk.end");
+  assert.ok(types.includes("stage.start"), "expected stage.start");
+  assert.ok(types.includes("stage.end"), "expected stage.end");
+  assert.ok(types.includes("gate.result"), "expected gate.result");
+
+  const runStart = events.find((event) => event.type === "run.start") as TelemetryEvent;
+  const runEnd = events.find((event) => event.type === "run.end") as TelemetryEvent;
+  assert.equal(runStart.runId, runEnd.runId);
+  assert.match(runStart.runId, /^run_/);
+
+  const stageEnds = events.filter((event) => event.type === "stage.end");
+  assert.ok(stageEnds.length >= 1);
+  for (const event of stageEnds) {
+    assert.equal(typeof event.durationMs, "number");
+    assert.equal(typeof event.inputTokens, "number");
+    assert.equal(typeof event.outputTokens, "number");
+  }
+
+  const gateResults = events.filter((event) => event.type === "gate.result");
+  assert.ok(gateResults.length >= 1);
+  assert.equal((gateResults[0]!.meta as Record<string, unknown>).hardPass, true);
+});
+
+test("translateMarkdownArticle emits stage.error when an LLM stage fails", async () => {
+  const source = ["# Hello", "", "World."].join("\n");
+  const sink = createMemoryTelemetrySink();
+
+  const executor: CodexExecutor = {
+    async execute(prompt: string): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(createEmptyAnchorCatalog());
+      }
+      throw new CodexExecutionError("draft synthetic failure");
+    }
+  };
+
+  await assert.rejects(
+    () =>
+      translateMarkdownArticle(source, {
+        executor,
+        formatter: async (markdown) => markdown,
+        telemetry: sink
+      })
+  );
+
+  const stageErrors = [...sink.events].filter((event) => event.type === "stage.error");
+  assert.ok(stageErrors.length >= 1, "expected at least one stage.error event");
+  for (const event of stageErrors) {
+    assert.equal(event.error, "draft synthetic failure");
+    assert.equal(typeof event.durationMs, "number");
+  }
+
+  const runEnd = [...sink.events].find((event) => event.type === "run.end");
+  assert.ok(runEnd, "expected run.end emitted on failure");
+  assert.equal((runEnd!.meta as Record<string, unknown>).failed, true);
 });
 


### PR DESCRIPTION
## Summary

Phase 1 of the throughput/quality initiative — establish observability foundation so subsequent improvements can be validated. Adds zero-cost-when-disabled telemetry to every LLM stage, chunk, repair cycle, and gate result.

- 新增 `src/telemetry.ts`：sink 抽象 + noop / 内存 / JSONL / 组合实现，`generateRunId` 提供稳定 run id 形态。
- `executeStageWithTimeout` 作为所有 LLM 调用的唯一通路，统一发 `stage.start` / `stage.end` / `stage.error`，附 duration、input/cached/output tokens、prompt 长度。
- `translateMarkdownArticle` 在入口/出口发 `run.start` / `run.end`；chunk 循环发 `chunk.start` / `chunk.end` / `chunk.error`；repair 循环每轮发 `repair.cycle`；audit 后发 `gate.result`；analysis shard 发 `analysis.shard.start` / `analysis.shard.end`。
- `TranslateOptions.telemetry` 公开字段；未传时若 `MDZH_TELEMETRY_PATH` 设置，自动建 JSONL sink 并由 run 内自闭合。
- CLI help 文档新增 Telemetry 段。

## Verification

- `npm run verify` 通过：247 单元测试 + typecheck + build。
- 新增 `test/telemetry.test.ts`（8 项）覆盖 sink 行为、JSONL 落盘、coalesce、广播。
- `test/translate.test.ts` 增 2 项端到端集成测试：成功路径事件序列、失败路径 `stage.error` + `run.end(failed=true)`。

## Notes

- 默认 sink 是 noop，性能开销可忽略。
- 没有挂 GitHub issue（本地研究任务），属 Phase 1 of 提效路线（Phase 2 = prompt caching + 差分 repair；Phase 3 = chunk 间并行；Phase 4 = TM）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)