### PR TITLE
feat: 引入 repair 差分补丁旁路

### DIFF
--- a/src/repair-patch.ts
+++ b/src/repair-patch.ts
@@ -1,0 +1,144 @@
+import type { RepairTask } from "./translation-state.js";
+
+/**
+ * Programmatic application of structured repair patches.
+ *
+ * The hard gate audit already produces `repair_targets` with explicit
+ * `currentText` / `targetText` for many failures. Historically we still asked
+ * the LLM to rewrite the whole segment to apply them, which is both slow and
+ * the dominant source of "repair caused unrelated drift". When the patch can
+ * be applied as a literal, unique replacement on the protected body, the LLM
+ * call adds nothing — we can apply the change ourselves and leave the rest of
+ * the segment untouched, by construction.
+ *
+ * This module is intentionally conservative:
+ * - The patch applies only when `currentText` matches exactly once.
+ * - Patches must not introduce or break protected-span placeholders
+ *   (`@@MDZH_*@@`).
+ * - Anything else (multiple matches, missing currentText, placeholder issues)
+ *   is left to the LLM repair lane.
+ */
+
+const PROTECTED_PLACEHOLDER_PATTERN = /@@MDZH_[A-Z_]+_\d{4}@@/g;
+
+export type PatchSkipReason =
+  | "no_structured_target"
+  | "missing_current_or_target"
+  | "current_not_found"
+  | "current_text_ambiguous"
+  | "current_contains_placeholder"
+  | "target_contains_placeholder"
+  | "target_changes_placeholder_count";
+
+export type PatchAttemptOutcome =
+  | { status: "applied"; taskId: string; before: string; after: string }
+  | { status: "skipped"; taskId: string; reason: PatchSkipReason };
+
+export type RepairPatchResult = {
+  patchedBody: string;
+  appliedTaskIds: string[];
+  remainingTasks: RepairTask[];
+  attempts: PatchAttemptOutcome[];
+};
+
+function countPlaceholders(text: string): number {
+  PROTECTED_PLACEHOLDER_PATTERN.lastIndex = 0;
+  let count = 0;
+  while (PROTECTED_PLACEHOLDER_PATTERN.exec(text) !== null) {
+    count += 1;
+  }
+  return count;
+}
+
+function containsPlaceholder(text: string): boolean {
+  PROTECTED_PLACEHOLDER_PATTERN.lastIndex = 0;
+  return PROTECTED_PLACEHOLDER_PATTERN.test(text);
+}
+
+function uniqueIndexOf(haystack: string, needle: string): number {
+  const first = haystack.indexOf(needle);
+  if (first < 0) {
+    return -1;
+  }
+  const second = haystack.indexOf(needle, first + needle.length);
+  if (second >= 0) {
+    return -2;
+  }
+  return first;
+}
+
+/**
+ * Try to apply each task's `structuredTarget` as a literal patch on the
+ * protected body. Tasks that can't be applied safely are returned unchanged
+ * for the LLM repair lane to handle.
+ */
+export function applyStructuredRepairPatches(
+  protectedBody: string,
+  tasks: readonly RepairTask[]
+): RepairPatchResult {
+  const attempts: PatchAttemptOutcome[] = [];
+  const appliedTaskIds: string[] = [];
+  const remainingTasks: RepairTask[] = [];
+  let body = protectedBody;
+
+  for (const task of tasks) {
+    const target = task.structuredTarget;
+    if (!target) {
+      attempts.push({ status: "skipped", taskId: task.id, reason: "no_structured_target" });
+      remainingTasks.push(task);
+      continue;
+    }
+
+    const currentText = target.currentText?.trim() ?? "";
+    const targetText = target.targetText?.trim() ?? "";
+    if (!currentText || !targetText || currentText === targetText) {
+      attempts.push({ status: "skipped", taskId: task.id, reason: "missing_current_or_target" });
+      remainingTasks.push(task);
+      continue;
+    }
+
+    if (containsPlaceholder(currentText)) {
+      attempts.push({ status: "skipped", taskId: task.id, reason: "current_contains_placeholder" });
+      remainingTasks.push(task);
+      continue;
+    }
+    if (containsPlaceholder(targetText)) {
+      attempts.push({ status: "skipped", taskId: task.id, reason: "target_contains_placeholder" });
+      remainingTasks.push(task);
+      continue;
+    }
+
+    const matchIndex = uniqueIndexOf(body, currentText);
+    if (matchIndex === -1) {
+      attempts.push({ status: "skipped", taskId: task.id, reason: "current_not_found" });
+      remainingTasks.push(task);
+      continue;
+    }
+    if (matchIndex === -2) {
+      attempts.push({ status: "skipped", taskId: task.id, reason: "current_text_ambiguous" });
+      remainingTasks.push(task);
+      continue;
+    }
+
+    const before = body.slice(0, matchIndex);
+    const after = body.slice(matchIndex + currentText.length);
+    const next = before + targetText + after;
+
+    if (countPlaceholders(next) !== countPlaceholders(body)) {
+      attempts.push({ status: "skipped", taskId: task.id, reason: "target_changes_placeholder_count" });
+      remainingTasks.push(task);
+      continue;
+    }
+
+    body = next;
+    appliedTaskIds.push(task.id);
+    attempts.push({ status: "applied", taskId: task.id, before: currentText, after: targetText });
+  }
+
+  return {
+    patchedBody: body,
+    appliedTaskIds,
+    remainingTasks,
+    attempts
+  };
+}

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -11,6 +11,7 @@ export type TelemetryEventType =
   | "chunk.end"
   | "chunk.error"
   | "repair.cycle"
+  | "repair.patch"
   | "gate.result"
   | "analysis.shard.start"
   | "analysis.shard.end";

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -35,6 +35,7 @@ import {
   noopTelemetry,
   type TelemetrySink
 } from "./telemetry.js";
+import { applyStructuredRepairPatches } from "./repair-patch.js";
 import { planMarkdownChunks, type MarkdownChunk, type MarkdownChunkPlan } from "./markdown-chunks.js";
 import {
   extractTranslatableStrongEmphasisSpans,
@@ -89,6 +90,18 @@ import {
 
 const DEFAULT_MODEL = "gpt-5.4-mini";
 const MAX_REPAIR_CYCLES = 2;
+
+function isRepairPatchLaneEnabled(): boolean {
+  // Default to enabled. Set MDZH_REPAIR_PATCH_LANE=false to fall back to the
+  // historical "ask the LLM to rewrite the segment" path. Useful when bisecting
+  // regressions or when the patch lane misses a pattern we want the model to
+  // handle.
+  const raw = process.env.MDZH_REPAIR_PATCH_LANE?.trim().toLowerCase();
+  if (!raw) {
+    return true;
+  }
+  return raw !== "false" && raw !== "0" && raw !== "off";
+}
 const MAX_MUST_FIX_PER_REPAIR_CALL = 1;
 const DRAFT_REASONING_EFFORT = "low";
 const AUDIT_REASONING_EFFORT = "low";
@@ -4799,7 +4812,8 @@ function suppressCoveredAnchorMustFix(
 
   return {
     hard_checks: nextHardChecks,
-    must_fix: remainingMustFix
+    must_fix: remainingMustFix,
+    ...(audit.repair_targets ? { repair_targets: audit.repair_targets } : {})
   };
 }
 
@@ -6812,6 +6826,54 @@ async function repairDraftedSegment(
     );
     const batchSuffix =
       repairTaskBatches.length > 1 ? `，修复批次 ${batchIndex + 1}/${repairTaskBatches.length}` : "";
+
+    if (isRepairPatchLaneEnabled()) {
+      const patchOutcome = applyStructuredRepairPatches(draftedSegment.protectedBody, taskBatch);
+      const skipReasons = patchOutcome.attempts
+        .filter((attempt) => attempt.status === "skipped")
+        .map((attempt) => (attempt as { reason: string }).reason);
+      context.telemetry.emit({
+        ts: Date.now(),
+        runId: context.runId,
+        type: "repair.patch",
+        chunkId: context.chunkId,
+        meta: {
+          segmentIndex: draftedSegment.segment.index + 1,
+          batch: `${batchIndex + 1}/${repairTaskBatches.length}`,
+          attempted: taskBatch.length,
+          applied: patchOutcome.appliedTaskIds.length,
+          ...(skipReasons.length ? { skipReasons } : {})
+        }
+      });
+
+      if (
+        patchOutcome.appliedTaskIds.length > 0 &&
+        patchOutcome.remainingTasks.length === 0
+      ) {
+        report(
+          context.options,
+          "repair",
+          `Chunk ${draftedSegment.promptContext.chunkIndex}/${plan.chunks.length}${chunkLabel}, segment ${draftedSegment.segment.index + 1}${batchSuffix}: applied ${patchOutcome.appliedTaskIds.length} structured patch(es) without invoking the model.`
+        );
+        draftedSegment.protectedBody = patchOutcome.patchedBody;
+        draftedSegment.restoredBody = restoreMarkdownSpans(
+          patchOutcome.patchedBody,
+          draftedSegment.spans
+        );
+        applyRepairResult(
+          context.state,
+          draftedSegment.segmentId,
+          patchOutcome.appliedTaskIds,
+          {
+            protectedBody: draftedSegment.protectedBody,
+            restoredBody: draftedSegment.restoredBody,
+            ...(draftedSegment.threadId ? { threadId: draftedSegment.threadId } : {})
+          }
+        );
+        continue;
+      }
+    }
+
     report(
       context.options,
       "repair",

--- a/test/repair-patch.test.ts
+++ b/test/repair-patch.test.ts
@@ -1,0 +1,212 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { applyStructuredRepairPatches } from "../src/repair-patch.js";
+import type { RepairTask } from "../src/translation-state.js";
+
+function makeTask(overrides: Partial<RepairTask> & { id: string }): RepairTask {
+  return {
+    segmentId: "chunk-1-segment-1",
+    anchorId: null,
+    failureType: "missing_anchor",
+    locationLabel: "第 1 个项目符号",
+    instruction: "首现需补双语",
+    status: "pending",
+    ...overrides
+  };
+}
+
+test("applies a unique-match patch and returns the new body", () => {
+  const body = "- npm 是包管理器。\n";
+  const result = applyStructuredRepairPatches(body, [
+    makeTask({
+      id: "r1",
+      structuredTarget: {
+        location: "第 1 个项目符号",
+        kind: "list_item",
+        currentText: "npm",
+        targetText: "npm 注册表（npm registry）"
+      }
+    })
+  ]);
+
+  assert.equal(result.patchedBody, "- npm 注册表（npm registry） 是包管理器。\n");
+  assert.deepEqual(result.appliedTaskIds, ["r1"]);
+  assert.equal(result.remainingTasks.length, 0);
+  assert.equal(result.attempts.length, 1);
+  assert.equal(result.attempts[0]!.status, "applied");
+});
+
+test("skips ambiguous current text appearing more than once", () => {
+  const body = "npm 一处。npm 又一处。";
+  const task = makeTask({
+    id: "r1",
+    structuredTarget: {
+      location: "第 1 处",
+      kind: "list_item",
+      currentText: "npm",
+      targetText: "npm 注册表"
+    }
+  });
+  const result = applyStructuredRepairPatches(body, [task]);
+
+  assert.equal(result.patchedBody, body);
+  assert.deepEqual(result.appliedTaskIds, []);
+  assert.equal(result.remainingTasks[0], task);
+  assert.equal(result.attempts[0]!.status, "skipped");
+  assert.equal((result.attempts[0] as { reason: string }).reason, "current_text_ambiguous");
+});
+
+test("skips when current text is missing entirely", () => {
+  const body = "完全无关的内容。";
+  const task = makeTask({
+    id: "r1",
+    structuredTarget: {
+      location: "第 1 处",
+      kind: "list_item",
+      currentText: "npm",
+      targetText: "npm 注册表"
+    }
+  });
+  const result = applyStructuredRepairPatches(body, [task]);
+
+  assert.equal(result.patchedBody, body);
+  assert.equal((result.attempts[0] as { reason: string }).reason, "current_not_found");
+});
+
+test("skips when structuredTarget is missing", () => {
+  const body = "样例正文";
+  const task = makeTask({ id: "r1" });
+  const result = applyStructuredRepairPatches(body, [task]);
+
+  assert.equal((result.attempts[0] as { reason: string }).reason, "no_structured_target");
+});
+
+test("skips when currentText or targetText is missing or equal", () => {
+  const body = "abc";
+  const result = applyStructuredRepairPatches(body, [
+    makeTask({
+      id: "r1",
+      structuredTarget: { location: "x", kind: "list_item", currentText: "a", targetText: "" }
+    }),
+    makeTask({
+      id: "r2",
+      structuredTarget: { location: "x", kind: "list_item", currentText: "a", targetText: "a" }
+    })
+  ]);
+
+  assert.equal(result.appliedTaskIds.length, 0);
+  for (const attempt of result.attempts) {
+    assert.equal(attempt.status, "skipped");
+    assert.equal((attempt as { reason: string }).reason, "missing_current_or_target");
+  }
+});
+
+test("refuses to patch a placeholder-bearing currentText", () => {
+  const body = "前文 @@MDZH_LINK_DESTINATION_0001@@ 后文";
+  const task = makeTask({
+    id: "r1",
+    structuredTarget: {
+      location: "x",
+      kind: "list_item",
+      currentText: "前文 @@MDZH_LINK_DESTINATION_0001@@",
+      targetText: "中文（English）"
+    }
+  });
+
+  const result = applyStructuredRepairPatches(body, [task]);
+  assert.equal(result.patchedBody, body);
+  assert.equal((result.attempts[0] as { reason: string }).reason, "current_contains_placeholder");
+});
+
+test("refuses to patch when target would introduce a placeholder pattern", () => {
+  const body = "中文";
+  const task = makeTask({
+    id: "r1",
+    structuredTarget: {
+      location: "x",
+      kind: "list_item",
+      currentText: "中文",
+      targetText: "中文 @@MDZH_LINK_DESTINATION_0099@@ 说明"
+    }
+  });
+  const result = applyStructuredRepairPatches(body, [task]);
+  assert.equal(result.patchedBody, body);
+  assert.equal((result.attempts[0] as { reason: string }).reason, "target_contains_placeholder");
+});
+
+test("applies multiple compatible patches sequentially", () => {
+  const body = "alpha 与 beta 各自独立。";
+  const result = applyStructuredRepairPatches(body, [
+    makeTask({
+      id: "r1",
+      structuredTarget: {
+        location: "x",
+        kind: "anchor",
+        currentText: "alpha",
+        targetText: "alpha（甲）"
+      }
+    }),
+    makeTask({
+      id: "r2",
+      structuredTarget: {
+        location: "y",
+        kind: "anchor",
+        currentText: "beta",
+        targetText: "beta（乙）"
+      }
+    })
+  ]);
+
+  assert.equal(result.patchedBody, "alpha（甲） 与 beta（乙） 各自独立。");
+  assert.deepEqual(result.appliedTaskIds, ["r1", "r2"]);
+  assert.equal(result.remainingTasks.length, 0);
+});
+
+test("partial application: some tasks land, others stay for the LLM lane", () => {
+  const body = "alpha 一处。重复 重复 出现两次。";
+  const result = applyStructuredRepairPatches(body, [
+    makeTask({
+      id: "r1",
+      structuredTarget: {
+        location: "x",
+        kind: "anchor",
+        currentText: "alpha",
+        targetText: "alpha（甲）"
+      }
+    }),
+    makeTask({
+      id: "r2",
+      structuredTarget: {
+        location: "y",
+        kind: "anchor",
+        currentText: "重复",
+        targetText: "已修"
+      }
+    })
+  ]);
+
+  assert.equal(result.patchedBody, "alpha（甲） 一处。重复 重复 出现两次。");
+  assert.deepEqual(result.appliedTaskIds, ["r1"]);
+  assert.equal(result.remainingTasks.length, 1);
+  assert.equal(result.remainingTasks[0]!.id, "r2");
+});
+
+test("preserves all protected placeholders in the body", () => {
+  const body = "前 @@MDZH_LINK_DESTINATION_0001@@ alpha 后 @@MDZH_AUTOLINK_0002@@";
+  const result = applyStructuredRepairPatches(body, [
+    makeTask({
+      id: "r1",
+      structuredTarget: {
+        location: "x",
+        kind: "anchor",
+        currentText: "alpha",
+        targetText: "alpha（甲）"
+      }
+    })
+  ]);
+
+  assert.match(result.patchedBody, /@@MDZH_LINK_DESTINATION_0001@@/);
+  assert.match(result.patchedBody, /@@MDZH_AUTOLINK_0002@@/);
+  assert.equal(result.patchedBody, "前 @@MDZH_LINK_DESTINATION_0001@@ alpha（甲） 后 @@MDZH_AUTOLINK_0002@@");
+});

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -3418,3 +3418,158 @@ test("translateMarkdownArticle emits stage.error when an LLM stage fails", async
   assert.equal((runEnd!.meta as Record<string, unknown>).failed, true);
 });
 
+test("repair patch lane short-circuits the LLM when structured targets fully cover the must_fix batch", async () => {
+  // Use a source that will NOT match any formal known_entities so the
+  // upstream `injectPlannedAnchorText` doesn't auto-apply the canonical form
+  // before the patch lane gets a chance.
+  const source = "- foobar widget\n";
+  const sink = createMemoryTelemetrySink();
+
+  let repairCalls = 0;
+  let auditPasses = 0;
+
+  const executor: CodexExecutor = {
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(createEmptyAnchorCatalog());
+      }
+
+      if (isBundledAuditPrompt(prompt, options) || prompt.includes("只返回 JSON") && prompt.includes("hard_checks")) {
+        if (auditPasses === 0) {
+          auditPasses += 1;
+          const failingAudit: GateAudit = {
+            hard_checks: {
+              paragraph_match: { pass: true, problem: "" },
+              first_mention_bilingual: { pass: true, problem: "" },
+              numbers_units_logic: { pass: false, problem: "需补 foobar 小工具的双语锚定。" },
+              chinese_punctuation: { pass: true, problem: "" },
+              unit_conversion_boundary: { pass: true, problem: "" },
+              protected_span_integrity: { pass: true, problem: "" }
+            },
+            must_fix: ["第 1 个项目符号需补 foobar 小工具（foobar widget）首现双语。"],
+            repair_targets: [
+              {
+                location: "第 1 个项目符号",
+                kind: "list_item",
+                currentText: "foobar 小工具",
+                targetText: "foobar 小工具（foobar widget）",
+                english: "foobar widget",
+                chineseHint: "foobar 小工具"
+              }
+            ]
+          };
+          return createExecResult(wrapAuditForSegments(prompt, failingAudit));
+        }
+        return createExecResult(wrapAuditForSegments(prompt, createAudit(true)));
+      }
+
+      if (options.outputSchema && prompt.includes("### BLOCK")) {
+        const blockCount = (prompt.match(/^### BLOCK \d+ \([^)]+\)$/gm) ?? []).length || 1;
+        return createExecResult(JSON.stringify({ blocks: Array.from({ length: blockCount }, () => "- foobar 小工具") }));
+      }
+
+      if (prompt.includes("【must_fix】")) {
+        repairCalls += 1;
+        return createExecResult("- foobar 小工具（foobar widget）。\n");
+      }
+
+      const current = extractPromptSection(prompt, "【当前译文】");
+      if (current !== null) {
+        return createExecResult(current);
+      }
+
+      return createExecResult("- foobar 小工具\n");
+    }
+  };
+
+  await translateMarkdownArticle(source, {
+    executor,
+    formatter: async (markdown) => markdown,
+    softGate: true,
+    telemetry: sink
+  });
+
+  const patchEvents = [...sink.events].filter((event) => event.type === "repair.patch");
+  assert.ok(patchEvents.length >= 1, "expected at least one repair.patch event");
+  const appliedTotal = patchEvents.reduce(
+    (sum, event) => sum + Number((event.meta as Record<string, unknown>).applied ?? 0),
+    0
+  );
+  assert.ok(appliedTotal >= 1, `expected at least one structured patch to apply, got ${appliedTotal}`);
+  assert.equal(repairCalls, 0, "patch lane should have skipped the LLM repair call");
+});
+
+test("repair patch lane falls through to the LLM when MDZH_REPAIR_PATCH_LANE=false", async () => {
+  const source = "- foobar widget\n";
+
+  let repairCalls = 0;
+  let auditPasses = 0;
+
+  const executor: CodexExecutor = {
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(createEmptyAnchorCatalog());
+      }
+      if (isBundledAuditPrompt(prompt, options) || prompt.includes("只返回 JSON") && prompt.includes("hard_checks")) {
+        if (auditPasses === 0) {
+          auditPasses += 1;
+          const failingAudit: GateAudit = {
+            hard_checks: {
+              paragraph_match: { pass: true, problem: "" },
+              first_mention_bilingual: { pass: true, problem: "" },
+              numbers_units_logic: { pass: false, problem: "需补 foobar 小工具双语。" },
+              chinese_punctuation: { pass: true, problem: "" },
+              unit_conversion_boundary: { pass: true, problem: "" },
+              protected_span_integrity: { pass: true, problem: "" }
+            },
+            must_fix: ["第 1 个项目符号需补首现双语。"],
+            repair_targets: [
+              {
+                location: "第 1 个项目符号",
+                kind: "list_item",
+                currentText: "foobar 小工具",
+                targetText: "foobar 小工具（foobar widget）",
+                english: "foobar widget",
+                chineseHint: "foobar 小工具"
+              }
+            ]
+          };
+          return createExecResult(wrapAuditForSegments(prompt, failingAudit));
+        }
+        return createExecResult(wrapAuditForSegments(prompt, createAudit(true)));
+      }
+      if (options.outputSchema && prompt.includes("### BLOCK")) {
+        const blockCount = (prompt.match(/^### BLOCK \d+ \([^)]+\)$/gm) ?? []).length || 1;
+        return createExecResult(JSON.stringify({ blocks: Array.from({ length: blockCount }, () => "- foobar 小工具") }));
+      }
+      if (prompt.includes("【must_fix】")) {
+        repairCalls += 1;
+        return createExecResult("- foobar 小工具（foobar widget）。\n");
+      }
+      const current = extractPromptSection(prompt, "【当前译文】");
+      if (current !== null) {
+        return createExecResult(current);
+      }
+      return createExecResult("- foobar 小工具\n");
+    }
+  };
+
+  const previous = process.env.MDZH_REPAIR_PATCH_LANE;
+  process.env.MDZH_REPAIR_PATCH_LANE = "false";
+  try {
+    await translateMarkdownArticle(source, {
+      executor,
+      formatter: async (markdown) => markdown,
+      softGate: true
+    });
+  } finally {
+    if (previous === undefined) {
+      delete process.env.MDZH_REPAIR_PATCH_LANE;
+    } else {
+      process.env.MDZH_REPAIR_PATCH_LANE = previous;
+    }
+  }
+
+  assert.equal(repairCalls, 1, "with patch lane disabled, repair LLM must be called once");
+});
+


### PR DESCRIPTION
## Summary

Phase 2B of the throughput/quality initiative. When the hard gate audit returns a `repair_targets` entry with explicit `currentText` / `targetText`, apply it as a literal patch on the protected body and skip the LLM repair call entirely. The historical "ask the LLM to rewrite the whole segment" path is preserved as a fallback for any task the patch lane can't handle safely.

- 新增 `src/repair-patch.ts`：保守的字面量补丁应用器，单次唯一匹配 + protected-span placeholder 校验 + 占位符计数守恒。
- `repairDraftedSegment` 每个 task batch 先走补丁旁路；全批命中则直接 `applyRepairResult` 并 continue，不调 LLM。
- 修上游 bug：`suppressCoveredAnchorMustFix` 之前在返回时未保留 `audit.repair_targets`，导致 `buildRepairTasksForSegment` 拿不到 structured target——属 Phase 2B 必要前置。
- 新 telemetry 事件 `repair.patch`（attempted / applied / skipReasons），后续可量化命中率与失败原因。
- env `MDZH_REPAIR_PATCH_LANE=false` 一键回退。

## Why

差分 repair 是校准报告里 Top-3 风险点之一：原 repair 让 LLM 整段重写，"只修 must_fix" 是 prompt 约束，无程序保证。补丁旁路通过构造性约束消除该漂移面。同时省掉一次 LLM 调用。

第一次带 telemetry 的 short smoke 跑出来 cache hit 34.6%，repair 阶段平均 8 秒/调用——这条路径是真实瓶颈。

## Verification

- `npm run verify` 通过：259 单元测试 + typecheck + build。
- 新增 `test/repair-patch.test.ts`（10 项）：唯一/多匹配/缺失/占位符防护/部分应用/计数守恒。
- 新增 `test/translate.test.ts` 2 项端到端：lane 启用时 0 LLM 调用；关闭后路径回退到 LLM。
- 现存的 reify 测试（涉及 structuredTarget 读出）继续通过——证明上游 bug 修复没破坏既有断言。

## Notes

- 上游 bug 修复独立成立，但和 Phase 2B 紧耦合（不修则补丁旁路对真实失败几乎不可能命中）。如果想拆开，可单独提一份「fix: 保留 suppressCoveredAnchorMustFix 中的 repair_targets」+ Phase 2B 的实现 PR。
- 没有挂 GitHub issue（本地研究任务）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)