### PR TITLE
feat: 引入 chunk 间并发翻译

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,6 +74,14 @@ Telemetry:
     to that file. Path is resolved relative to the working directory. One line per
     event; useful for offline analysis of latency, token usage, and repair behavior.
 
+Performance knobs:
+  - MDZH_CHUNK_CONCURRENCY=<N> (default 1, max 8) runs up to N
+    translateProtectedChunk calls in parallel. Result push, state mutation and
+    checkpoint writes still happen in chunk-index order, so the final document
+    and resume semantics are unchanged.
+  - MDZH_REPAIR_PATCH_LANE=false disables the structured repair-target patch
+    lane and forces the historical full-segment LLM rewrite for every repair.
+
 Exit codes:
   0  Success (may include soft-gate degraded output; see stderr for warnings).
   2  Invalid arguments or missing input.

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -10,6 +10,7 @@ export type TelemetryEventType =
   | "chunk.start"
   | "chunk.end"
   | "chunk.error"
+  | "chunk.concurrency"
   | "repair.cycle"
   | "repair.patch"
   | "gate.result"

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -91,6 +91,25 @@ import {
 const DEFAULT_MODEL = "gpt-5.4-mini";
 const MAX_REPAIR_CYCLES = 2;
 
+function readChunkConcurrency(): number {
+  // Bounded chunk-level parallelism. Defaults to 1 (the historical serial
+  // pipeline). Set MDZH_CHUNK_CONCURRENCY=N (N≥1) to run up to N
+  // translateProtectedChunk calls in parallel; result push, state mutation
+  // and checkpoint writes still happen strictly in chunk-index order so
+  // resume semantics and final document order are preserved.
+  const raw = process.env.MDZH_CHUNK_CONCURRENCY?.trim();
+  if (!raw) {
+    return 1;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return 1;
+  }
+  // Hard ceiling: too much parallelism mostly buys throttling on the LLM
+  // backend without meaningful speedup. 8 is a generous upper bound.
+  return Math.min(parsed, 8);
+}
+
 function isRepairPatchLaneEnabled(): boolean {
   // Default to enabled. Set MDZH_REPAIR_PATCH_LANE=false to fall back to the
   // historical "ask the LLM to rewrite the segment" path. Useful when bisecting
@@ -2765,12 +2784,38 @@ export async function translateMarkdownArticle(source: string, options: Translat
       }
     }
 
-    for (const chunk of chunkPlan.chunks) {
+    type ChunkOutcome = {
+      chunkResult: ChunkTranslationResult;
+      chunkId: string;
+      chunkStartedAt: number;
+    };
+
+    const concurrency = readChunkConcurrency();
+    telemetry.emit({
+      ts: Date.now(),
+      runId,
+      type: "chunk.concurrency",
+      meta: { concurrency, totalChunks: chunkPlan.chunks.length }
+    });
+
+    const chunkOutcomes: Array<ChunkOutcome | null> = new Array(chunkPlan.chunks.length).fill(
+      null
+    );
+    let nextChunkToFinalize = 0;
+    let cancelError: unknown = null;
+    const finalizationLock = { busy: false };
+
+    const runChunk = async (chunk: MarkdownChunk): Promise<void> => {
+      if (cancelError) {
+        return;
+      }
       const chunkId = `chunk-${chunk.index + 1}`;
       if (completedCheckpointChunks.some((entry) => entry.chunkId === chunkId)) {
         report(options, "draft", `Skipping ${chunkId}; restored from checkpoint.`);
-        continue;
+        chunkOutcomes[chunk.index] = null;
+        return;
       }
+
       const chunkStartedAt = Date.now();
       telemetry.emit({
         ts: chunkStartedAt,
@@ -2784,7 +2829,8 @@ export async function translateMarkdownArticle(source: string, options: Translat
           chunkChars: chunk.source.length
         }
       });
-      let chunkResult;
+
+      let chunkResult: ChunkTranslationResult;
       try {
         chunkResult = await translateProtectedChunk(chunk, chunkPlan, {
           state,
@@ -2819,7 +2865,13 @@ export async function translateMarkdownArticle(source: string, options: Translat
             error: errorMessage,
             meta: { recovered: false, structural: isStructuralHardGateError(error) }
           });
-          throw error;
+          // Save the first error so other in-flight chunks can short-circuit
+          // and the run rejects after the worker pool drains. Subsequent
+          // failures are dropped on the floor — we already have a reason.
+          if (!cancelError) {
+            cancelError = error;
+          }
+          return;
         }
         telemetry.emit({
           ts: Date.now(),
@@ -2861,25 +2913,79 @@ export async function translateMarkdownArticle(source: string, options: Translat
         }
       });
 
-      restoredChunks.push(chunkResult.body + chunk.separatorAfter);
-      gateAudits.push(chunkResult.gateAudit);
-      repairCyclesUsed += chunkResult.repairCyclesUsed;
-      nextLocalSpanIndex = chunkResult.nextLocalSpanIndex;
-      setChunkFinalBody(state, chunkId, chunkResult.body);
-      completedCheckpointChunks.push({
-        chunkId,
-        body: chunkResult.body,
-        gateAudit: chunkResult.gateAudit
-      });
-      if (checkpointDir && checkpointKey) {
-        const checkpointPath = await writeTranslationCheckpoint(checkpointDir, checkpointKey, {
-          state,
-          completedChunks: completedCheckpointChunks,
-          repairCyclesUsed,
-          nextLocalSpanIndex
-        });
-        report(options, "draft", `Updated translation checkpoint at ${checkpointPath}.`);
+      chunkOutcomes[chunk.index] = { chunkResult, chunkId, chunkStartedAt };
+
+      // Try to finalize as many in-order completed chunks as we can. Only one
+      // worker may be inside this loop at a time so the state mutations remain
+      // serial even when N workers hand outcomes off concurrently.
+      if (finalizationLock.busy) {
+        return;
       }
+      finalizationLock.busy = true;
+      try {
+        while (
+          nextChunkToFinalize < chunkOutcomes.length &&
+          (cancelError === null || cancelError === undefined) &&
+          (chunkOutcomes[nextChunkToFinalize] !== null ||
+            completedCheckpointChunks.some(
+              (entry) => entry.chunkId === `chunk-${nextChunkToFinalize + 1}`
+            ))
+        ) {
+          const outcome = chunkOutcomes[nextChunkToFinalize];
+          const finalizingChunk = chunkPlan.chunks[nextChunkToFinalize]!;
+          if (!outcome) {
+            // Already restored from checkpoint — nothing to do beyond skipping.
+            nextChunkToFinalize += 1;
+            continue;
+          }
+
+          restoredChunks.push(outcome.chunkResult.body + finalizingChunk.separatorAfter);
+          gateAudits.push(outcome.chunkResult.gateAudit);
+          repairCyclesUsed += outcome.chunkResult.repairCyclesUsed;
+          nextLocalSpanIndex = outcome.chunkResult.nextLocalSpanIndex;
+          setChunkFinalBody(state, outcome.chunkId, outcome.chunkResult.body);
+          completedCheckpointChunks.push({
+            chunkId: outcome.chunkId,
+            body: outcome.chunkResult.body,
+            gateAudit: outcome.chunkResult.gateAudit
+          });
+          if (checkpointDir && checkpointKey) {
+            const checkpointPath = await writeTranslationCheckpoint(checkpointDir, checkpointKey, {
+              state,
+              completedChunks: completedCheckpointChunks,
+              repairCyclesUsed,
+              nextLocalSpanIndex
+            });
+            report(options, "draft", `Updated translation checkpoint at ${checkpointPath}.`);
+          }
+          nextChunkToFinalize += 1;
+        }
+      } finally {
+        finalizationLock.busy = false;
+      }
+    };
+
+    // Worker pool: each worker pulls the next pending chunk off the queue
+    // until empty or until cancellation kicks in. With concurrency=1 this is
+    // exactly the historical sequential behaviour.
+    const queue = [...chunkPlan.chunks];
+    const worker = async () => {
+      while (true) {
+        if (cancelError) {
+          return;
+        }
+        const next = queue.shift();
+        if (!next) {
+          return;
+        }
+        await runChunk(next);
+      }
+    };
+    const workers = Array.from({ length: Math.max(1, concurrency) }, () => worker());
+    await Promise.all(workers);
+
+    if (cancelError) {
+      throw cancelError;
     }
 
     let translatedBody = restoredChunks.join("");

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -3573,3 +3573,140 @@ test("repair patch lane falls through to the LLM when MDZH_REPAIR_PATCH_LANE=fal
   assert.equal(repairCalls, 1, "with patch lane disabled, repair LLM must be called once");
 });
 
+test("MDZH_CHUNK_CONCURRENCY=2 preserves chunk order in the final document", async () => {
+  const source = [
+    "## Alpha",
+    "",
+    "Alpha body line.",
+    "",
+    "## Bravo",
+    "",
+    "Bravo body line.",
+    "",
+    "## Charlie",
+    "",
+    "Charlie body line.",
+    ""
+  ].join("\n");
+
+  const draftLatencyByMarker: Record<string, number> = {
+    Alpha: 80,
+    Bravo: 0,
+    Charlie: 40
+  };
+
+  const sink = createMemoryTelemetrySink();
+  const executor: CodexExecutor = {
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(createEmptyAnchorCatalog());
+      }
+      if (isBundledAuditPrompt(prompt, options) || (options.outputSchema && prompt.includes('"hard_checks"'))) {
+        return createExecResult(wrapAuditForSegments(prompt, createAudit(true)));
+      }
+      const sourceSection = extractPromptSection(prompt, "【英文原文】") ?? "";
+      const marker =
+        sourceSection.includes("Alpha") ? "Alpha"
+        : sourceSection.includes("Bravo") ? "Bravo"
+        : sourceSection.includes("Charlie") ? "Charlie"
+        : null;
+      if (marker) {
+        const wait = draftLatencyByMarker[marker] ?? 0;
+        await new Promise((resolve) => setTimeout(resolve, wait));
+        // Echo the source heading verbatim so the draft contract is satisfied;
+        // only translate the body line and inject the marker token so the test
+        // can detect chunk order in the final document.
+        const translated = sourceSection
+          .replace(`## ${marker}`, `## ${marker}`)
+          .replace(`${marker} body line.`, `译文 ${marker} 正文。`);
+        return createExecResult(translated);
+      }
+      return createExecResult(sourceSection);
+    }
+  };
+
+  const previous = process.env.MDZH_CHUNK_CONCURRENCY;
+  process.env.MDZH_CHUNK_CONCURRENCY = "2";
+  let result;
+  try {
+    result = await translateMarkdownArticle(source, {
+      executor,
+      formatter: async (markdown) => markdown,
+      telemetry: sink
+    });
+  } finally {
+    if (previous === undefined) {
+      delete process.env.MDZH_CHUNK_CONCURRENCY;
+    } else {
+      process.env.MDZH_CHUNK_CONCURRENCY = previous;
+    }
+  }
+
+  const alphaIdx = result.markdown.indexOf("译文 Alpha");
+  const bravoIdx = result.markdown.indexOf("译文 Bravo");
+  const charlieIdx = result.markdown.indexOf("译文 Charlie");
+  assert.ok(alphaIdx >= 0 && bravoIdx >= 0 && charlieIdx >= 0, "all chunks should appear");
+  assert.ok(alphaIdx < bravoIdx, "Alpha must come before Bravo");
+  assert.ok(bravoIdx < charlieIdx, "Bravo must come before Charlie");
+
+  const concurrencyEvent = [...sink.events].find((event) => event.type === "chunk.concurrency");
+  assert.ok(concurrencyEvent, "expected chunk.concurrency event");
+  assert.equal((concurrencyEvent!.meta as Record<string, unknown>).concurrency, 2);
+});
+
+test("default concurrency runs chunks strictly serial — chunk N+1 starts only after chunk N ends", async () => {
+  const source = ["## A", "", "Body A.", "", "## B", "", "Body B.", ""].join("\n");
+
+  const startTimestamps: Array<{ chunkId: string; ts: number }> = [];
+  const endTimestamps: Array<{ chunkId: string; ts: number }> = [];
+
+  const memory = createMemoryTelemetrySink();
+  const executor: CodexExecutor = {
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(createEmptyAnchorCatalog());
+      }
+      if (isBundledAuditPrompt(prompt, options) || (options.outputSchema && prompt.includes('"hard_checks"'))) {
+        return createExecResult(wrapAuditForSegments(prompt, createAudit(true)));
+      }
+      const sourceSection = extractPromptSection(prompt, "【英文原文】") ?? "";
+      return createExecResult(sourceSection);
+    }
+  };
+
+  await translateMarkdownArticle(source, {
+    executor,
+    formatter: async (markdown) => markdown,
+    telemetry: {
+      emit(event) {
+        memory.emit(event);
+        if (event.type === "chunk.start" && event.chunkId) {
+          startTimestamps.push({ chunkId: event.chunkId, ts: event.ts });
+        } else if (event.type === "chunk.end" && event.chunkId) {
+          endTimestamps.push({ chunkId: event.chunkId, ts: event.ts });
+        }
+      },
+      async close() {
+        await memory.close();
+      }
+    }
+  });
+
+  for (let index = 1; index < startTimestamps.length; index += 1) {
+    const previousEnd = endTimestamps[index - 1]?.ts;
+    const currentStart = startTimestamps[index]?.ts;
+    assert.ok(
+      typeof previousEnd === "number" && typeof currentStart === "number",
+      "chunk start/end events must carry timestamps"
+    );
+    assert.ok(
+      currentStart! >= previousEnd!,
+      `chunk ${startTimestamps[index]!.chunkId} started before previous chunk ended — concurrency leakage`
+    );
+  }
+
+  const concurrencyEvent = [...memory.events].find((event) => event.type === "chunk.concurrency");
+  assert.ok(concurrencyEvent, "expected chunk.concurrency event");
+  assert.equal((concurrencyEvent!.meta as Record<string, unknown>).concurrency, 1);
+});
+


### PR DESCRIPTION
## Summary

Phase 3 of the throughput initiative. The chunk loop in `translateMarkdownArticle` is now a bounded worker pool driven by `MDZH_CHUNK_CONCURRENCY` (default 1, max 8). Multiple `translateProtectedChunk` calls can run in parallel, but post-translation state mutations (push results, mark final body, write checkpoint) are guarded by a single-holder finalization lock and processed strictly in chunk-index order.

- 默认并发=1 → 与改造前完全一致的串行行为。
- `MDZH_CHUNK_CONCURRENCY=N`（N≥2）→ 多 chunk 同时跑 LLM 调用；最终文档顺序、resume prefix 语义、checkpoint 内容都不变。
- 第一个非 soft-gate 错误会写入 `cancelError`，其它 worker 下次抢任务时立即退出（不继续烧 LLM）。
- 新增 `chunk.concurrency` telemetry 事件，便于后续按并发级别观察实际加速比。

## Why

校准报告里 chunk-level parallelism 是 Phase 3 重点：当前 audit 占总耗时 ~60%，多 chunk 间没有共享的强一致状态（spans 计数事实上是死参数），并行有显著速度收益。

## Verification

- `npm run verify` 通过：261 单元测试 + typecheck + build。
- 新增 2 项端到端测试：
  - concurrency=2 + Bravo 比 Alpha 早返回 → 文档仍按 Alpha→Bravo→Charlie 顺序。
  - 默认 concurrency=1 → chunk N+1 的 `chunk.start` 时间戳 ≥ chunk N 的 `chunk.end`，证明无并发泄漏。

## Notes

- 锁定上限为 8，避免过度调用 backend 反被限流。
- 没有挂 GitHub issue（本地研究任务）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)