### PR TITLE
feat: 引入 segment 级 translation memory

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -81,6 +81,11 @@ Performance knobs:
     and resume semantics are unchanged.
   - MDZH_REPAIR_PATCH_LANE=false disables the structured repair-target patch
     lane and forces the historical full-segment LLM rewrite for every repair.
+  - MDZH_TM_PATH=<path> enables segment-level translation memory at <path>
+    (JSONL). The pipeline reads cached translations on draft and writes back
+    only when a chunk hard-passes. Use it to short-circuit identical re-runs
+    (e.g. iterating on the same fixture). Audit and repair still run on TM
+    hits, so a stale entry can't silently leak through.
 
 Exit codes:
   0  Success (may include soft-gate degraded output; see stderr for warnings).

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -14,6 +14,9 @@ export type TelemetryEventType =
   | "repair.cycle"
   | "repair.patch"
   | "gate.result"
+  | "tm.hit"
+  | "tm.miss"
+  | "tm.write"
   | "analysis.shard.start"
   | "analysis.shard.end";
 

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -36,6 +36,12 @@ import {
   type TelemetrySink
 } from "./telemetry.js";
 import { applyStructuredRepairPatches } from "./repair-patch.js";
+import {
+  createJsonlTmStore,
+  fingerprint as tmFingerprint,
+  noopTmStore,
+  type TmStore
+} from "./translation-memory.js";
 import { planMarkdownChunks, type MarkdownChunk, type MarkdownChunkPlan } from "./markdown-chunks.js";
 import {
   extractTranslatableStrongEmphasisSpans,
@@ -245,6 +251,14 @@ export type TranslateOptions = {
    * care pay nothing.
    */
   telemetry?: TelemetrySink;
+  /**
+   * Optional segment-level translation memory. When provided and a segment's
+   * source matches a previously hard-passed entry, the draft LLM call is
+   * skipped and the cached target is reused as the segment draft. Audit and
+   * repair still run, so stale entries don't silently leak through. Default
+   * is a no-op store.
+   */
+  tmStore?: TmStore;
 };
 
 export type TranslateResult = {
@@ -2678,6 +2692,20 @@ export async function translateMarkdownArticle(source: string, options: Translat
   } else {
     telemetry = noopTelemetry;
   }
+  // TM resolution mirrors telemetry: caller-supplied store wins, otherwise
+  // MDZH_TM_PATH opens a JSONL store for this run, otherwise noop.
+  let ownedTmStore: TmStore | null = null;
+  let tmStore: TmStore;
+  if (options.tmStore) {
+    tmStore = options.tmStore;
+  } else if (process.env.MDZH_TM_PATH?.trim()) {
+    ownedTmStore = await createJsonlTmStore(
+      path.resolve(cwd, process.env.MDZH_TM_PATH.trim())
+    );
+    tmStore = ownedTmStore;
+  } else {
+    tmStore = noopTmStore;
+  }
   const runId = generateRunId();
   const runStartedAt = Date.now();
   telemetry.emit({
@@ -2846,7 +2874,8 @@ export async function translateMarkdownArticle(source: string, options: Translat
           draftReasoningEffort: DRAFT_REASONING_EFFORT as ReasoningEffort,
           postDraftReasoningEffort,
           runId,
-          telemetry
+          telemetry,
+          tmStore
         });
       } catch (error) {
         // Soft-gate fallback for any chunk-level error (HardGateError from
@@ -3050,6 +3079,9 @@ export async function translateMarkdownArticle(source: string, options: Translat
     if (ownedTelemetry) {
       await ownedTelemetry.close();
     }
+    if (ownedTmStore) {
+      await ownedTmStore.close();
+    }
     return result;
   } catch (error) {
     await writeDebugStateIfRequested(state);
@@ -3064,6 +3096,9 @@ export async function translateMarkdownArticle(source: string, options: Translat
     });
     if (ownedTelemetry) {
       await ownedTelemetry.close();
+    }
+    if (ownedTmStore) {
+      await ownedTmStore.close();
     }
     if (error instanceof HardGateError || error instanceof FormattingError) {
       throw error;
@@ -3136,6 +3171,7 @@ type ChunkTranslationContext = {
   postDraftReasoningEffort: ReasoningEffort | undefined;
   runId: string;
   telemetry: TelemetrySink;
+  tmStore: TmStore;
 };
 
 type ChunkTranslationResult = {
@@ -5221,6 +5257,53 @@ async function translateProtectedChunk(
     });
   }
 
+  // Write hard-passed segments to translation memory so future runs of the
+  // same source can short-circuit the draft LLM call. We only persist when
+  // the entire chunk hard-passed — a chunk-level pass is the strongest
+  // evidence we have that each segment's translation is correct.
+  if (isBundledHardPass(bundledAudit)) {
+    for (const drafted of draftedSegments) {
+      const segmentAudit = bundledAudit.segments.find(
+        (entry) => entry.segment_index === drafted.segment.index + 1
+      );
+      if (!segmentAudit || !isHardPass(segmentAudit)) {
+        continue;
+      }
+      try {
+        await context.tmStore.put({
+          fingerprint: tmFingerprint(drafted.segment.source),
+          source: drafted.segment.source,
+          target: drafted.protectedBody,
+          hardPassed: true,
+          auditedAt: Date.now(),
+          runId: context.runId
+        });
+        context.telemetry.emit({
+          ts: Date.now(),
+          runId: context.runId,
+          type: "tm.write",
+          chunkId: context.chunkId,
+          meta: {
+            segmentIndex: drafted.segment.index + 1,
+            sourceChars: drafted.segment.source.length
+          }
+        });
+      } catch (error) {
+        // TM persistence is best-effort; never fail the run because the cache
+        // file couldn't be written.
+        const message = error instanceof Error ? error.message : String(error);
+        context.telemetry.emit({
+          ts: Date.now(),
+          runId: context.runId,
+          type: "tm.write",
+          chunkId: context.chunkId,
+          error: message,
+          meta: { segmentIndex: drafted.segment.index + 1 }
+        });
+      }
+    }
+  }
+
   if (!isBundledHardPass(bundledAudit)) {
     const failedSegments = bundledAudit.segments
       .filter((audit) => !isHardPass(audit))
@@ -6172,6 +6255,52 @@ async function translateProtectedSegment(
   const localFormatting = protectSegmentFormattingSpans(segment.source, localSpanStartIndex);
   const protectedSource = localFormatting.protectedBody;
   const combinedSpans = [...localFormatting.spans, ...segment.spans];
+
+  // TM short-circuit: if a previous run hard-passed translation for this exact
+  // segment source (with the same protected-span IDs), reuse the cached
+  // protectedBody as our draft. Audit + repair still run on top, so a stale or
+  // wrong cached target won't silently leak through. Fingerprinting the raw
+  // segment.source (with placeholder IDs embedded) means hits only fire when
+  // the document layout truly matches — safe for smoke re-runs.
+  const tmKey = tmFingerprint(segment.source);
+  const cachedTm = context.tmStore.get(tmKey);
+  if (cachedTm?.hardPassed) {
+    context.telemetry.emit({
+      ts: Date.now(),
+      runId: context.runId,
+      type: "tm.hit",
+      chunkId: context.chunkId,
+      meta: {
+        segmentIndex: segment.index + 1,
+        sourceChars: segment.source.length,
+        cachedRunId: cachedTm.runId
+      }
+    });
+    const cachedProtectedBody = cachedTm.target;
+    const cachedRestoredBody = restoreMarkdownSpans(cachedProtectedBody, combinedSpans);
+    applySegmentDraft(context.state, segmentId, {
+      protectedSource,
+      protectedBody: cachedProtectedBody,
+      restoredBody: cachedRestoredBody
+    });
+    return {
+      segment,
+      segmentId,
+      promptContext: chunkPromptContext,
+      protectedSource,
+      protectedBody: cachedProtectedBody,
+      restoredBody: cachedRestoredBody,
+      spans: combinedSpans
+    };
+  }
+  context.telemetry.emit({
+    ts: Date.now(),
+    runId: context.runId,
+    type: "tm.miss",
+    chunkId: context.chunkId,
+    meta: { segmentIndex: segment.index + 1 }
+  });
+
   const structuralSegmentDraft = classifyStructuralSegmentDraftStrategy(protectedSource);
 
   report(

--- a/src/translation-memory.ts
+++ b/src/translation-memory.ts
@@ -1,0 +1,128 @@
+import { createHash } from "node:crypto";
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * Segment-level translation memory.
+ *
+ * The pipeline is deterministic in its segmentation: the same source segment
+ * should produce the same canonical placeholder body, and the gate audit
+ * already tells us when a translation is correct. So if we have already
+ * translated `segment.source` to `target` and that target passed the hard
+ * gate before, we can short-circuit the entire draft + audit + repair loop
+ * for that segment by just returning the stored target.
+ *
+ * Scope for v1:
+ * - Exact match only (fingerprint = SHA1 of normalized source text).
+ * - Append-only JSONL on disk; we de-dup in-memory by fingerprint.
+ * - No fuzzy match, no per-document scoping. Future iterations can layer
+ *   those on top by extending TmEntry with similarity metadata.
+ */
+
+export type TmEntry = {
+  fingerprint: string;
+  source: string;
+  target: string;
+  hardPassed: boolean;
+  auditedAt: number;
+  runId: string;
+  documentTitle?: string;
+};
+
+export interface TmStore {
+  get(fingerprint: string): TmEntry | null;
+  put(entry: TmEntry): Promise<void>;
+  close(): Promise<void>;
+}
+
+export const noopTmStore: TmStore = {
+  get() {
+    return null;
+  },
+  async put() {
+    // no-op
+  },
+  async close() {
+    // no-op
+  }
+};
+
+export function fingerprint(source: string): string {
+  // Normalize whitespace so trivial line-ending or tab differences don't
+  // cause a miss. Keep punctuation and case — they carry meaning the model
+  // would otherwise translate differently.
+  const normalized = source.replace(/\r\n/g, "\n").replace(/[ \t]+\n/g, "\n").trim();
+  return createHash("sha1").update(normalized, "utf8").digest("hex");
+}
+
+export function createMemoryTmStore(initial: readonly TmEntry[] = []): TmStore & {
+  readonly entries: readonly TmEntry[];
+} {
+  const map = new Map<string, TmEntry>();
+  for (const entry of initial) {
+    map.set(entry.fingerprint, entry);
+  }
+  return {
+    get entries(): readonly TmEntry[] {
+      return [...map.values()];
+    },
+    get(fp) {
+      return map.get(fp) ?? null;
+    },
+    async put(entry) {
+      map.set(entry.fingerprint, entry);
+    },
+    async close() {
+      // no-op
+    }
+  };
+}
+
+export async function createJsonlTmStore(filePath: string): Promise<TmStore> {
+  const map = new Map<string, TmEntry>();
+  let writeChain = Promise.resolve();
+
+  // Eagerly load existing entries; bad / incomplete lines are skipped quietly
+  // so a partially-written JSONL from a crashed run doesn't poison the cache.
+  try {
+    const raw = await readFile(filePath, "utf8");
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        continue;
+      }
+      try {
+        const entry = JSON.parse(trimmed) as TmEntry;
+        if (
+          typeof entry?.fingerprint === "string" &&
+          typeof entry?.source === "string" &&
+          typeof entry?.target === "string"
+        ) {
+          map.set(entry.fingerprint, entry);
+        }
+      } catch {
+        // Skip unparseable line.
+      }
+    }
+  } catch {
+    // File doesn't exist yet — fine, first run.
+  }
+
+  return {
+    get(fp) {
+      return map.get(fp) ?? null;
+    },
+    async put(entry) {
+      map.set(entry.fingerprint, entry);
+      const append = (async () => {
+        await mkdir(path.dirname(filePath), { recursive: true });
+        await appendFile(filePath, `${JSON.stringify(entry)}\n`, "utf8");
+      })();
+      writeChain = writeChain.then(() => append);
+      await append;
+    },
+    async close() {
+      await writeChain;
+    }
+  };
+}

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -19,6 +19,7 @@ import {
 import { CodexExecutionError } from "../src/errors.js";
 import type { CodexExecOptions, CodexExecResult, CodexExecutor } from "../src/codex-exec.js";
 import { createMemoryTelemetrySink, type TelemetryEvent } from "../src/telemetry.js";
+import { createMemoryTmStore, fingerprint as tmFingerprint } from "../src/translation-memory.js";
 
 function isDocumentAnalysisPrompt(prompt: string): boolean {
   return prompt.includes("【文档分析输入】");
@@ -3708,5 +3709,141 @@ test("default concurrency runs chunks strictly serial — chunk N+1 starts only 
   const concurrencyEvent = [...memory.events].find((event) => event.type === "chunk.concurrency");
   assert.ok(concurrencyEvent, "expected chunk.concurrency event");
   assert.equal((concurrencyEvent!.meta as Record<string, unknown>).concurrency, 1);
+});
+
+test("Translation Memory hit short-circuits the draft LLM call and reuses the cached target", async () => {
+  const source = "## Hello\n\nWorld.\n";
+  const sink = createMemoryTelemetrySink();
+
+  let draftCalls = 0;
+  const cachedTarget = "## 你好\n\n世界。\n";
+
+  // Pre-seed the TM with the cached target, fingerprinted from the segment
+  // source the pipeline will produce. We don't know the exact protected-span
+  // splits up-front, so this is the simplest cross-check: the only segment
+  // here has no spans, so segment.source === source body of the chunk minus
+  // separators. Use a snapshot fingerprint based on the full source minus
+  // the trailing newline.
+  const tm = createMemoryTmStore();
+
+  const executor: CodexExecutor = {
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(createEmptyAnchorCatalog());
+      }
+      if (isBundledAuditPrompt(prompt, options) || (options.outputSchema && prompt.includes('"hard_checks"'))) {
+        return createExecResult(wrapAuditForSegments(prompt, createAudit(true)));
+      }
+      // Any draft / json-blocks call should never fire on a TM hit.
+      draftCalls += 1;
+      const sourceSection = extractPromptSection(prompt, "【英文原文】") ?? "";
+      return createExecResult(sourceSection);
+    }
+  };
+
+  // First run: TM is cold. The pipeline drafts via the executor and writes a
+  // hard-passed entry into the TM.
+  await translateMarkdownArticle(source, {
+    executor,
+    formatter: async (markdown) => markdown,
+    telemetry: sink,
+    tmStore: tm
+  });
+  assert.ok(draftCalls > 0, "first run should still call the draft LLM");
+  const writtenAfterFirstRun = tm.entries.length;
+  assert.ok(writtenAfterFirstRun > 0, "first run should populate at least one TM entry");
+
+  // Second run: with TM warmed, every segment's draft LLM call should be
+  // skipped — only audit (and any other non-draft stages) should fire.
+  draftCalls = 0;
+  const sink2 = createMemoryTelemetrySink();
+  void cachedTarget;
+  await translateMarkdownArticle(source, {
+    executor,
+    formatter: async (markdown) => markdown,
+    telemetry: sink2,
+    tmStore: tm
+  });
+
+  assert.equal(draftCalls, 0, "with a warm TM, no draft LLM calls should fire");
+  const hits = [...sink2.events].filter((event) => event.type === "tm.hit");
+  assert.ok(hits.length >= 1, "second run should emit at least one tm.hit event");
+});
+
+test("Translation Memory writes only when the chunk hard-passes", async () => {
+  const source = "## Hello\n\nWorld.\n";
+  const tm = createMemoryTmStore();
+  const sink = createMemoryTelemetrySink();
+
+  // Force a hard-gate failure: the audit reports failure repeatedly, the run
+  // exhausts MAX_REPAIR_CYCLES and (with softGate=false) throws HardGateError.
+  // We expect the TM to remain empty because no chunk actually passed.
+  const executor: CodexExecutor = {
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(createEmptyAnchorCatalog());
+      }
+      if (isBundledAuditPrompt(prompt, options) || (options.outputSchema && prompt.includes('"hard_checks"'))) {
+        const failingAudit: GateAudit = {
+          ...createAudit(false, ["第 1 段需补 first 锚定。"], {
+            first_mention_bilingual: { pass: false, problem: "缺首现双语。" },
+            chinese_punctuation: { pass: false, problem: "标点缺失。" }
+          })
+        };
+        return createExecResult(wrapAuditForSegments(prompt, failingAudit));
+      }
+      const current = extractPromptSection(prompt, "【当前译文】");
+      if (current !== null) {
+        return createExecResult(current);
+      }
+      const sourceSection = extractPromptSection(prompt, "【英文原文】") ?? "";
+      return createExecResult(sourceSection);
+    }
+  };
+
+  await assert.rejects(
+    () =>
+      translateMarkdownArticle(source, {
+        executor,
+        formatter: async (markdown) => markdown,
+        softGate: false,
+        telemetry: sink,
+        tmStore: tm
+      })
+  );
+
+  assert.equal(tm.entries.length, 0, "no TM entries should be written when no chunk hard-passes");
+  const writes = [...sink.events].filter((event) => event.type === "tm.write");
+  assert.equal(writes.length, 0, "no tm.write events should fire when no chunk hard-passes");
+});
+
+test("Translation Memory miss event fires when no entry exists for the segment", async () => {
+  const source = "## Hello\n\nWorld.\n";
+  const tm = createMemoryTmStore();
+  const sink = createMemoryTelemetrySink();
+
+  const executor: CodexExecutor = {
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(createEmptyAnchorCatalog());
+      }
+      if (isBundledAuditPrompt(prompt, options) || (options.outputSchema && prompt.includes('"hard_checks"'))) {
+        return createExecResult(wrapAuditForSegments(prompt, createAudit(true)));
+      }
+      const sourceSection = extractPromptSection(prompt, "【英文原文】") ?? "";
+      return createExecResult(sourceSection);
+    }
+  };
+
+  await translateMarkdownArticle(source, {
+    executor,
+    formatter: async (markdown) => markdown,
+    telemetry: sink,
+    tmStore: tm
+  });
+
+  const misses = [...sink.events].filter((event) => event.type === "tm.miss");
+  assert.ok(misses.length >= 1, "first run with cold TM should emit at least one tm.miss event");
+  void tmFingerprint;
 });
 

--- a/test/translation-memory.test.ts
+++ b/test/translation-memory.test.ts
@@ -1,0 +1,114 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  createJsonlTmStore,
+  createMemoryTmStore,
+  fingerprint,
+  noopTmStore,
+  type TmEntry
+} from "../src/translation-memory.js";
+
+function makeEntry(overrides: Partial<TmEntry> & { source: string; target: string }): TmEntry {
+  return {
+    fingerprint: fingerprint(overrides.source),
+    hardPassed: true,
+    auditedAt: 1700000000000,
+    runId: "run_test",
+    ...overrides
+  };
+}
+
+test("fingerprint normalizes line endings and trailing whitespace", () => {
+  const a = fingerprint("hello\nworld\n");
+  const b = fingerprint("hello\r\nworld\r\n");
+  const c = fingerprint("hello \nworld\t\n");
+  assert.equal(a, b);
+  assert.equal(a, c);
+});
+
+test("fingerprint is case- and punctuation-sensitive", () => {
+  const lower = fingerprint("hello world.");
+  const upper = fingerprint("Hello World.");
+  const noPunct = fingerprint("hello world");
+  assert.notEqual(lower, upper);
+  assert.notEqual(lower, noPunct);
+});
+
+test("noopTmStore is a clean no-op", async () => {
+  assert.equal(noopTmStore.get("anything"), null);
+  await noopTmStore.put(makeEntry({ source: "x", target: "y" }));
+  await noopTmStore.close();
+});
+
+test("createMemoryTmStore round-trips entries", async () => {
+  const store = createMemoryTmStore();
+  const entry = makeEntry({ source: "Hello World.", target: "你好世界。" });
+  await store.put(entry);
+  const got = store.get(entry.fingerprint);
+  assert.deepEqual(got, entry);
+  assert.equal(store.entries.length, 1);
+});
+
+test("createMemoryTmStore lookup miss returns null", () => {
+  const store = createMemoryTmStore();
+  assert.equal(store.get("missing"), null);
+});
+
+test("createMemoryTmStore put replaces an existing entry by fingerprint", async () => {
+  const store = createMemoryTmStore();
+  const a = makeEntry({ source: "X", target: "甲" });
+  const b = makeEntry({ source: "X", target: "丙", auditedAt: 1700000001000 });
+  await store.put(a);
+  await store.put(b);
+  assert.equal(store.entries.length, 1);
+  assert.equal(store.get(a.fingerprint)?.target, "丙");
+});
+
+test("createJsonlTmStore appends one JSON object per line and rehydrates", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "tm-test-"));
+  try {
+    const filePath = path.join(dir, "nested", "tm.jsonl");
+    const store1 = await createJsonlTmStore(filePath);
+    await store1.put(makeEntry({ source: "Alpha", target: "甲" }));
+    await store1.put(makeEntry({ source: "Bravo", target: "乙" }));
+    await store1.close();
+
+    const raw = await readFile(filePath, "utf8");
+    const lines = raw.split("\n").filter((line) => line.length > 0);
+    assert.equal(lines.length, 2);
+
+    const store2 = await createJsonlTmStore(filePath);
+    assert.equal(store2.get(fingerprint("Alpha"))?.target, "甲");
+    assert.equal(store2.get(fingerprint("Bravo"))?.target, "乙");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("createJsonlTmStore tolerates a partially written / corrupt file", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "tm-test-"));
+  try {
+    const filePath = path.join(dir, "tm.jsonl");
+    // First entry valid, second entry garbage, third entry valid.
+    const valid = makeEntry({ source: "Alpha", target: "甲" });
+    const garbage = "{{{not json";
+    const valid2 = makeEntry({ source: "Bravo", target: "乙" });
+    const lines = [
+      JSON.stringify(valid),
+      garbage,
+      JSON.stringify(valid2)
+    ].join("\n") + "\n";
+    await mkdtemp(path.join(tmpdir(), "tm-test-")); // ensure dir
+    await (await import("node:fs/promises")).writeFile(filePath, lines, "utf8");
+
+    const store = await createJsonlTmStore(filePath);
+    assert.equal(store.get(valid.fingerprint)?.target, "甲");
+    assert.equal(store.get(valid2.fingerprint)?.target, "乙");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Phase 4: TM as a draft cache. New `src/translation-memory.ts` exposes `TmStore` (noop / memory / JSONL implementations) plus a SHA1-based `fingerprint(source)` helper. `translateProtectedSegment` consults the TM before drafting; on hit (with `hardPassed: true`) it skips the draft LLM call and reuses the cached `protectedBody`. After a chunk hard-passes, each segment's translation is written back. Audit and repair still run on TM hits, so stale entries can't silently leak through.

`MDZH_TM_PATH=<path>` enables a JSONL-backed TM owned by the run; `options.tmStore` lets callers inject their own store (used by tests). New telemetry events: `tm.hit`, `tm.miss`, `tm.write`.

## Scope choices (v1)

- segment 级 exact match — placeholder IDs are embedded in the fingerprint so cross-document hits don't fire by accident.
- 仅在 chunk 整体 hard-pass 时写入。
- 没有 fuzzy / embedding / 跨 doc 命中（after we measure v1 effectiveness）。

## Why

Smoke 反复跑同一份 fixture 时，每次 draft 重做整段；TM 让相同段落直接复用上一次成功的译文。Phase 1 telemetry 显示 draft 阶段占 token 消耗 35%，Phase 2A 后 cache hit 提升到 70%——但相同输入仍要重跑一遍，TM 把这部分整段省掉。

## Verification

- `npm run verify` 通过：272 单元 + typecheck + build。
- 新增 `test/translation-memory.test.ts`（8 项）：fingerprint 归一化 / 损坏 JSONL 容错 / 落盘+重水化 / 替换语义。
- `test/translate.test.ts` 增 3 项端到端：暖 TM = 0 draft calls；chunk 失败时 TM 不写入；冷 TM 触发 tm.miss。

🤖 Generated with [Claude Code](https://claude.com/claude-code)