### PR TITLE
feat: rescue 模型默认 gpt-5.5；显式关闭语义

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -86,12 +86,13 @@ Performance knobs:
     only when a chunk hard-passes. Use it to short-circuit identical re-runs
     (e.g. iterating on the same fixture). Audit and repair still run on TM
     hits, so a stale entry can't silently leak through.
-  - MDZH_RESCUE_MODEL=<model-id> enables a stronger fallback model. When a
+  - MDZH_RESCUE_MODEL=<model-id> overrides the rescue fallback model. When a
     chunk exhausts its draft+audit+repair cycle and would otherwise throw
     HardGateError, the chunk is retried once end-to-end with this model
     substituted for both draft and post-draft. If the rescue also fails the
-    original error is reported. Trades cost & wall time for stability on
-    flaky chunks.
+    original error is reported. Defaults to \`gpt-5.5\`; set to an empty
+    string or \`off\` / \`none\` / \`false\` / \`0\` to disable rescue entirely.
+    Trades cost & wall time for stability on flaky chunks.
 
 Exit codes:
   0  Success (may include soft-gate degraded output; see stderr for warnings).

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -97,17 +97,32 @@ import {
 const DEFAULT_MODEL = "gpt-5.4-mini";
 const MAX_REPAIR_CYCLES = 2;
 
+const DEFAULT_RESCUE_MODEL = "gpt-5.5";
+
 function readRescueModel(): string | null {
-  // Optional stronger fallback model. When set, a chunk that exhausts its
-  // normal draft+audit+repair cycle and would otherwise throw HardGateError
-  // (or fail soft-gate's structural carve-out) is retried once end-to-end
-  // with this model substituted for both draftModel and postDraftModel. If
-  // the rescue also fails, the original error propagates.
-  const raw = process.env.MDZH_RESCUE_MODEL?.trim();
-  if (!raw) {
+  // Stronger fallback model used when a chunk exhausts its normal
+  // draft+audit+repair cycle and would otherwise throw HardGateError. The
+  // chunk is retried once end-to-end with this model substituted for both
+  // draftModel and postDraftModel; if the rescue also fails, the original
+  // error propagates.
+  //
+  // Defaults to `gpt-5.5` because long-form smoke validates that this model
+  // recovers list-content / structural failures the mini default reliably
+  // can't. To disable rescue entirely set MDZH_RESCUE_MODEL to an empty
+  // string or any of `off` / `none` / `false` / `0`.
+  const raw = process.env.MDZH_RESCUE_MODEL;
+  if (raw === undefined) {
+    return DEFAULT_RESCUE_MODEL;
+  }
+  const trimmed = raw.trim();
+  if (trimmed === "") {
     return null;
   }
-  return raw;
+  const lower = trimmed.toLowerCase();
+  if (lower === "off" || lower === "none" || lower === "false" || lower === "0") {
+    return null;
+  }
+  return trimmed;
 }
 
 function readChunkConcurrency(): number {

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -3950,7 +3950,47 @@ test("MDZH_RESCUE_MODEL surfaces the original error when the rescue also fails",
   assert.equal((rescueEnd!.meta as Record<string, unknown>).success, false);
 });
 
-test("default behavior: no MDZH_RESCUE_MODEL means no rescue attempt", async () => {
+test("default behavior: rescue defaults to gpt-5.5 when MDZH_RESCUE_MODEL is unset", async () => {
+  const source = "## Hello\n\nWorld.\n";
+
+  const executor: CodexExecutor = {
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(createEmptyAnchorCatalog());
+      }
+      if (isBundledAuditPrompt(prompt, options) || (options.outputSchema && prompt.includes('"hard_checks"'))) {
+        return createExecResult(wrapAuditForSegments(prompt, createAudit(true)));
+      }
+      const sourceSection = extractPromptSection(prompt, "【英文原文】") ?? "";
+      // Primary mini draft fails; the default rescue model recovers it.
+      if (options.model === "gpt-5.5") {
+        return createExecResult(sourceSection.replace("World.", "世界。"));
+      }
+      throw new CodexExecutionError("primary draft fail");
+    }
+  };
+
+  const previous = process.env.MDZH_RESCUE_MODEL;
+  delete process.env.MDZH_RESCUE_MODEL;
+  const sink = createMemoryTelemetrySink();
+  try {
+    await translateMarkdownArticle(source, {
+      executor,
+      formatter: async (markdown) => markdown,
+      telemetry: sink
+    });
+  } finally {
+    if (previous !== undefined) {
+      process.env.MDZH_RESCUE_MODEL = previous;
+    }
+  }
+
+  const rescueStart = [...sink.events].find((event) => event.type === "chunk.rescue.start");
+  assert.ok(rescueStart, "default rescue should fire when MDZH_RESCUE_MODEL is unset");
+  assert.equal((rescueStart!.meta as Record<string, unknown>).rescueModel, "gpt-5.5");
+});
+
+test("MDZH_RESCUE_MODEL=off explicitly disables rescue", async () => {
   const source = "## Hello\n\nWorld.\n";
 
   const executor: CodexExecutor = {
@@ -3966,7 +4006,7 @@ test("default behavior: no MDZH_RESCUE_MODEL means no rescue attempt", async () 
   };
 
   const previous = process.env.MDZH_RESCUE_MODEL;
-  delete process.env.MDZH_RESCUE_MODEL;
+  process.env.MDZH_RESCUE_MODEL = "off";
   const sink = createMemoryTelemetrySink();
   try {
     await assert.rejects(() =>
@@ -3977,12 +4017,14 @@ test("default behavior: no MDZH_RESCUE_MODEL means no rescue attempt", async () 
       })
     );
   } finally {
-    if (previous !== undefined) {
+    if (previous === undefined) {
+      delete process.env.MDZH_RESCUE_MODEL;
+    } else {
       process.env.MDZH_RESCUE_MODEL = previous;
     }
   }
 
   const rescueEvents = [...sink.events].filter((event) => event.type.startsWith("chunk.rescue"));
-  assert.equal(rescueEvents.length, 0, "no rescue events should fire when MDZH_RESCUE_MODEL is unset");
+  assert.equal(rescueEvents.length, 0, "no rescue events should fire when MDZH_RESCUE_MODEL=off");
 });
 


### PR DESCRIPTION
## Summary

实证验证后把 `gpt-5.5` 升为 rescue 默认。日常 run 自动获得 chunk 失败的兜底，不需要 export 环境变量。

- 默认：`gpt-5.5`
- 关闭：`MDZH_RESCUE_MODEL=` (空) / `off` / `none` / `false` / `0`
- 自定义：`MDZH_RESCUE_MODEL=<其他模型>`

## Why

长文 c=3 smoke 实证：chunk 4 primary 撞 list-content 缺失，rescue 用 gpt-5.5 跑 121s 后通过；整 run 21/21 chunks 干净完成。把这个能力默认开就不用每次记 env。

## Verification

- 276 单元 + typecheck + build 全绿。
- 原「未设 env 不触发」测试改为「未设 env → 默认 gpt-5.5 rescue」端到端。
- 新增「MDZH_RESCUE_MODEL=off 关闭」测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)