### PR TITLE
feat: chunk 默认并发 1 → 3

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -75,10 +75,10 @@ Telemetry:
     event; useful for offline analysis of latency, token usage, and repair behavior.
 
 Performance knobs:
-  - MDZH_CHUNK_CONCURRENCY=<N> (default 1, max 8) runs up to N
+  - MDZH_CHUNK_CONCURRENCY=<N> (default 3, max 8) runs up to N
     translateProtectedChunk calls in parallel. Result push, state mutation and
     checkpoint writes still happen in chunk-index order, so the final document
-    and resume semantics are unchanged.
+    and resume semantics are unchanged. Set to 1 to restore strict serial.
   - MDZH_REPAIR_PATCH_LANE=false disables the structured repair-target patch
     lane and forces the historical full-segment LLM rewrite for every repair.
   - MDZH_TM_PATH=<path> enables segment-level translation memory at <path>

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -125,19 +125,21 @@ function readRescueModel(): string | null {
   return trimmed;
 }
 
+const DEFAULT_CHUNK_CONCURRENCY = 3;
+
 function readChunkConcurrency(): number {
-  // Bounded chunk-level parallelism. Defaults to 1 (the historical serial
-  // pipeline). Set MDZH_CHUNK_CONCURRENCY=N (N≥1) to run up to N
-  // translateProtectedChunk calls in parallel; result push, state mutation
-  // and checkpoint writes still happen strictly in chunk-index order so
-  // resume semantics and final document order are preserved.
+  // Bounded chunk-level parallelism. Defaults to 3 — long-form c=3 smoke
+  // measured a 1.88× wall-time speedup with no correctness regressions
+  // (result push, state mutation and checkpoint writes still happen strictly
+  // in chunk-index order). Set MDZH_CHUNK_CONCURRENCY=N (N≥1) to override;
+  // 1 restores the historical serial pipeline.
   const raw = process.env.MDZH_CHUNK_CONCURRENCY?.trim();
   if (!raw) {
-    return 1;
+    return DEFAULT_CHUNK_CONCURRENCY;
   }
   const parsed = Number.parseInt(raw, 10);
   if (!Number.isFinite(parsed) || parsed < 1) {
-    return 1;
+    return DEFAULT_CHUNK_CONCURRENCY;
   }
   // Hard ceiling: too much parallelism mostly buys throttling on the LLM
   // backend without meaningful speedup. 8 is a generous upper bound.

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -2569,10 +2569,23 @@ test("translateMarkdownArticle includes established terms from prior chunks in l
   }
 
   const executor = new PriorAnchorExecutor();
-  await translateMarkdownArticle(source, {
-    executor,
-    formatter: async (markdown) => markdown
-  });
+  // Established-anchor flow only fires when chunk N-1 finishes audit before
+  // chunk N's slice is built — which requires strictly serial chunk
+  // processing. The default concurrency is 3 so we pin to 1 here.
+  const previousConcurrency = process.env.MDZH_CHUNK_CONCURRENCY;
+  process.env.MDZH_CHUNK_CONCURRENCY = "1";
+  try {
+    await translateMarkdownArticle(source, {
+      executor,
+      formatter: async (markdown) => markdown
+    });
+  } finally {
+    if (previousConcurrency === undefined) {
+      delete process.env.MDZH_CHUNK_CONCURRENCY;
+    } else {
+      process.env.MDZH_CHUNK_CONCURRENCY = previousConcurrency;
+    }
+  }
 
   const secondChunkPrompt = executor.prompts.find(
     (prompt) => !isDocumentAnalysisPrompt(prompt) && prompt.includes("当前分块：第 2 /")
@@ -2622,10 +2635,22 @@ test("translateMarkdownArticle does not carry generic prior headings into establ
   }
 
   const executor = new PriorAnchorExecutor();
-  await translateMarkdownArticle(source, {
-    executor,
-    formatter: async (markdown) => markdown
-  });
+  // Pin to serial: established-anchor propagation across chunks needs the
+  // prior chunk to finish before the next slice is built.
+  const previousConcurrency = process.env.MDZH_CHUNK_CONCURRENCY;
+  process.env.MDZH_CHUNK_CONCURRENCY = "1";
+  try {
+    await translateMarkdownArticle(source, {
+      executor,
+      formatter: async (markdown) => markdown
+    });
+  } finally {
+    if (previousConcurrency === undefined) {
+      delete process.env.MDZH_CHUNK_CONCURRENCY;
+    } else {
+      process.env.MDZH_CHUNK_CONCURRENCY = previousConcurrency;
+    }
+  }
 
   const secondChunkPrompt = executor.prompts.find(
     (prompt) => !isDocumentAnalysisPrompt(prompt) && prompt.includes("当前分块：第 2 /")
@@ -3655,7 +3680,7 @@ test("MDZH_CHUNK_CONCURRENCY=2 preserves chunk order in the final document", asy
   assert.equal((concurrencyEvent!.meta as Record<string, unknown>).concurrency, 2);
 });
 
-test("default concurrency runs chunks strictly serial — chunk N+1 starts only after chunk N ends", async () => {
+test("MDZH_CHUNK_CONCURRENCY=1 forces strict serial — chunk N+1 starts only after chunk N ends", async () => {
   const source = ["## A", "", "Body A.", "", "## B", "", "Body B.", ""].join("\n");
 
   const startTimestamps: Array<{ chunkId: string; ts: number }> = [];
@@ -3675,23 +3700,33 @@ test("default concurrency runs chunks strictly serial — chunk N+1 starts only 
     }
   };
 
-  await translateMarkdownArticle(source, {
-    executor,
-    formatter: async (markdown) => markdown,
-    telemetry: {
-      emit(event) {
-        memory.emit(event);
-        if (event.type === "chunk.start" && event.chunkId) {
-          startTimestamps.push({ chunkId: event.chunkId, ts: event.ts });
-        } else if (event.type === "chunk.end" && event.chunkId) {
-          endTimestamps.push({ chunkId: event.chunkId, ts: event.ts });
+  const previous = process.env.MDZH_CHUNK_CONCURRENCY;
+  process.env.MDZH_CHUNK_CONCURRENCY = "1";
+  try {
+    await translateMarkdownArticle(source, {
+      executor,
+      formatter: async (markdown) => markdown,
+      telemetry: {
+        emit(event) {
+          memory.emit(event);
+          if (event.type === "chunk.start" && event.chunkId) {
+            startTimestamps.push({ chunkId: event.chunkId, ts: event.ts });
+          } else if (event.type === "chunk.end" && event.chunkId) {
+            endTimestamps.push({ chunkId: event.chunkId, ts: event.ts });
+          }
+        },
+        async close() {
+          await memory.close();
         }
-      },
-      async close() {
-        await memory.close();
       }
+    });
+  } finally {
+    if (previous === undefined) {
+      delete process.env.MDZH_CHUNK_CONCURRENCY;
+    } else {
+      process.env.MDZH_CHUNK_CONCURRENCY = previous;
     }
-  });
+  }
 
   for (let index = 1; index < startTimestamps.length; index += 1) {
     const previousEnd = endTimestamps[index - 1]?.ts;
@@ -3709,6 +3744,42 @@ test("default concurrency runs chunks strictly serial — chunk N+1 starts only 
   const concurrencyEvent = [...memory.events].find((event) => event.type === "chunk.concurrency");
   assert.ok(concurrencyEvent, "expected chunk.concurrency event");
   assert.equal((concurrencyEvent!.meta as Record<string, unknown>).concurrency, 1);
+});
+
+test("default concurrency is 3 when MDZH_CHUNK_CONCURRENCY is unset", async () => {
+  const source = ["## A", "", "Body A.", "", "## B", "", "Body B.", ""].join("\n");
+
+  const memory = createMemoryTelemetrySink();
+  const executor: CodexExecutor = {
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(createEmptyAnchorCatalog());
+      }
+      if (isBundledAuditPrompt(prompt, options) || (options.outputSchema && prompt.includes('"hard_checks"'))) {
+        return createExecResult(wrapAuditForSegments(prompt, createAudit(true)));
+      }
+      const sourceSection = extractPromptSection(prompt, "【英文原文】") ?? "";
+      return createExecResult(sourceSection);
+    }
+  };
+
+  const previous = process.env.MDZH_CHUNK_CONCURRENCY;
+  delete process.env.MDZH_CHUNK_CONCURRENCY;
+  try {
+    await translateMarkdownArticle(source, {
+      executor,
+      formatter: async (markdown) => markdown,
+      telemetry: memory
+    });
+  } finally {
+    if (previous !== undefined) {
+      process.env.MDZH_CHUNK_CONCURRENCY = previous;
+    }
+  }
+
+  const concurrencyEvent = [...memory.events].find((event) => event.type === "chunk.concurrency");
+  assert.ok(concurrencyEvent, "expected chunk.concurrency event");
+  assert.equal((concurrencyEvent!.meta as Record<string, unknown>).concurrency, 3);
 });
 
 test("Translation Memory hit short-circuits the draft LLM call and reuses the cached target", async () => {


### PR DESCRIPTION
## Summary

实证后把 `MDZH_CHUNK_CONCURRENCY` 默认从 1 提到 3。日常 run 自动获得长文 1.88× 加速。

- 默认：`3`（实证长文 c=3 smoke 1.88× 加速 + 21/21 chunks 通过）
- 强制串行：`MDZH_CHUNK_CONCURRENCY=1`
- 自定义：`MDZH_CHUNK_CONCURRENCY=N`（1 ≤ N ≤ 8）

## Tradeoff（重要）

跨 chunk「已建立锚点」hint（`establishedAnchors`）在并发时间窗内可能缺失：chunk 2 的 slice 可能在 chunk 1 audit 完成前构建。模型仍能从静态 analysis 的 `firstOccurrence` 判断首现/重复，所以**不影响结构正确性**，只影响重复锚定的提示强度。

这是真实的语义降级，但实证（长文 c=3 smoke）不会触发结构 hard-gate。需要严格跨 chunk 锚点 hint 的调用方应显式 `export MDZH_CHUNK_CONCURRENCY=1`。

## Test changes

- 原「default 串行」断言改为「`MDZH_CHUNK_CONCURRENCY=1` 强制串行」端到端。
- 新增「未设 env → concurrency=3」断言。
- 两个跨 chunk 「已建立锚点」语义测试 pin 到 concurrency=1。

## Verification

- 277 单元 + typecheck + build 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)