### PR TITLE
feat: 新增 embedded_template_integrity 硬性项审校

### DIFF
--- a/src/internal/prompts/scheme-h.ts
+++ b/src/internal/prompts/scheme-h.ts
@@ -7,6 +7,7 @@ Markdown 结构要求：
 5. 如果原文正文使用了可翻译的 Markdown 强调结构（如 **加粗**、*斜体*）或命令/flag 写法（如 --flag），译文应保持等价结构；不要丢掉强调，也不要把普通命令/flag 误改成代码块、标题或其他 Markdown 结构。
 6. 列表项数必须与原文严格一致：原文每条 \`-\` / \`*\` / 数字编号必须对应译文中一条独立列表项，**不得合并、不得拆分、不得重复追加、不得整段化**。即使条目文字简短，也必须保持单独成行的 bullet/编号结构，不能把多条 bullets 拼成一个段落或一行。
 7. 项目符号 (\`-\`、\`*\`、\`+\`)、有序列表编号 (\`1.\` / \`1)\`)、引用前缀 (\`>\`)、分隔线 (\`---\`) 等行级 Markdown 标记必须按原文逐行保留，不要误删、不要换形式。
+8. 内嵌模板与类型签名字面保留：原文有时会在正文里**嵌入示例性的 Markdown 模板或代码片段**（例如 \`**# Feature Specification**\`、\`**## 1. Overview**\`、\`User { id: string, email: string }\`、\`Response: { photoId: string, success: boolean }\` 这类伪标题或类型签名）。这些**不是真正的文档结构**，而是字面示例：必须**整段照抄保留**（包括 \`**\` 强调、\`#\`/\`##\` 字符、\`{\`/\`}\` 大括号、\`:\` 分隔、\`string\`/\`boolean\`/\`number\` 等类型名、字段名 \`photoId\`/\`fileName\` 等）。**绝对不要**把 \`string\` 翻成「字符串」、\`boolean\` 翻成「布尔值」、\`number\` 翻成「数字」；也不要把伪标题里的英文名翻成中文。占位文字（如 \`[Feature Name]\`、\`[2–3 sentences]\`、\`[Exact endpoints and responses]\`）允许翻成中文。
 `.trim();
 
 export const DOCUMENT_ANALYSIS_PROMPT = `
@@ -224,7 +225,8 @@ export const GATE_AUDIT_PROMPT = `
     "numbers_units_logic": { "pass": true, "problem": "" },
     "chinese_punctuation": { "pass": true, "problem": "" },
     "unit_conversion_boundary": { "pass": true, "problem": "" },
-    "protected_span_integrity": { "pass": true, "problem": "" }
+    "protected_span_integrity": { "pass": true, "problem": "" },
+    "embedded_template_integrity": { "pass": true, "problem": "" }
   },
   "must_fix": [
     "逐条列出必须修复的问题，描述要具体、可执行"
@@ -261,6 +263,7 @@ export const GATE_AUDIT_PROMPT = `
 4. chinese_punctuation：是否符合中文标点习惯；如果保留完整英文段落，该英文段落内部可保留英文标点，不单独判错。中文句内若保留英文缩写并补中文解释，括号必须是全角，例如“CNN（美国有线电视新闻网）”。
 5. unit_conversion_boundary：长度、重量、华氏温度、以英寸表示的累计降水量是否按规则补常见换算，其他单位是否没有被擅自换算。
 6. protected_span_integrity：所有占位符是否逐字保留、没有丢失、没有改写、没有增删、没有被污染进别的文本。
+7. embedded_template_integrity：原文正文里**嵌入的示例性 Markdown 模板或类型签名**是否被字面保留。例如 \`**# Feature Specification**\`、\`**## 1. Overview**\`、\`User { id: string, email: string }\`、\`Response: { photoId: string, success: boolean }\`、\`POST /api/photos/upload\`、\`Request: FormData with file\` 这类伪标题、伪代码、类型签名块。如果出现「\`string\` 被翻成「字符串」」「\`boolean\` 被翻成「布尔值」」「字段名 \`photoId\`/\`fileName\`/\`uploadedAt\` 被译成中文」「伪标题里的英文名被翻译」「\`{ ... }\` 大括号块结构被改写或丢失」，都判为不通过；并在 must_fix 里写明位置和应恢复的字面文本（必要时填 repair_targets 的 currentText / targetText 直接修复）。占位文字如 \`[Feature Name]\`、\`[2–3 sentences]\`、\`[Tech stack, database design, API structure]\` 这类用方括号包起来的提示文字允许翻成中文，不算违规。
 
 输出要求：
 - 只返回 JSON。
@@ -298,7 +301,8 @@ export const BUNDLED_GATE_AUDIT_PROMPT = `
         "numbers_units_logic": { "pass": true, "problem": "" },
         "chinese_punctuation": { "pass": true, "problem": "" },
         "unit_conversion_boundary": { "pass": true, "problem": "" },
-        "protected_span_integrity": { "pass": true, "problem": "" }
+        "protected_span_integrity": { "pass": true, "problem": "" },
+        "embedded_template_integrity": { "pass": true, "problem": "" }
       },
       "must_fix": [
         "逐条列出必须修复的问题，描述要具体、可执行"
@@ -337,6 +341,7 @@ export const BUNDLED_GATE_AUDIT_PROMPT = `
 4. chinese_punctuation：是否符合中文标点习惯；如果保留完整英文段落，该英文段落内部可保留英文标点，不单独判错。中文句内若保留英文缩写并补中文解释，括号必须是全角，例如“CNN（美国有线电视新闻网）”。
 5. unit_conversion_boundary：长度、重量、华氏温度、以英寸表示的累计降水量是否按规则补常见换算，其他单位是否没有被擅自换算。
 6. protected_span_integrity：所有占位符是否逐字保留、没有丢失、没有改写、没有增删、没有被污染进别的文本。
+7. embedded_template_integrity：原文正文里**嵌入的示例性 Markdown 模板或类型签名**是否被字面保留。例如 \`**# Feature Specification**\`、\`**## 1. Overview**\`、\`User { id: string, email: string }\`、\`Response: { photoId: string, success: boolean }\`、\`POST /api/photos/upload\`、\`Request: FormData with file\` 这类伪标题、伪代码、类型签名块。如果出现「\`string\` 被翻成「字符串」」「\`boolean\` 被翻成「布尔值」」「字段名 \`photoId\`/\`fileName\`/\`uploadedAt\` 被译成中文」「伪标题里的英文名被翻译」「\`{ ... }\` 大括号块结构被改写或丢失」，都判为不通过；并在 must_fix 里写明位置和应恢复的字面文本（必要时填 repair_targets 的 currentText / targetText 直接修复）。占位文字如 \`[Feature Name]\`、\`[2–3 sentences]\`、\`[Tech stack, database design, API structure]\` 这类用方括号包起来的提示文字允许翻成中文，不算违规。
 
 输出要求：
 - 只返回 JSON。

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -228,7 +228,8 @@ type AuditCheckKey =
   | "numbers_units_logic"
   | "chinese_punctuation"
   | "unit_conversion_boundary"
-  | "protected_span_integrity";
+  | "protected_span_integrity"
+  | "embedded_template_integrity";
 
 export type GateAudit = {
   hard_checks: Record<AuditCheckKey, { pass: boolean; problem: string }>;
@@ -330,7 +331,8 @@ const GATE_AUDIT_SCHEMA = {
         "numbers_units_logic",
         "chinese_punctuation",
         "unit_conversion_boundary",
-        "protected_span_integrity"
+        "protected_span_integrity",
+        "embedded_template_integrity"
       ],
       properties: {
         paragraph_match: auditItemSchema(),
@@ -338,7 +340,8 @@ const GATE_AUDIT_SCHEMA = {
         numbers_units_logic: auditItemSchema(),
         chinese_punctuation: auditItemSchema(),
         unit_conversion_boundary: auditItemSchema(),
-        protected_span_integrity: auditItemSchema()
+        protected_span_integrity: auditItemSchema(),
+        embedded_template_integrity: auditItemSchema()
       }
     },
     must_fix: {
@@ -722,6 +725,10 @@ function parseGateAuditValue(value: unknown): GateAudit {
   const hardChecks = data.hard_checks;
   const mustFix = data.must_fix;
   const repairTargets = data.repair_targets;
+  // Required keys must be present in the audit response. embedded_template_
+  // integrity was added later and is parsed leniently below — it defaults to
+  // `{ pass: true, problem: "" }` when older audit prompts / fixtures don't
+  // emit it, so adding the check is non-breaking for legacy callers.
   const keys: AuditCheckKey[] = [
     "paragraph_match",
     "first_mention_bilingual",
@@ -745,6 +752,23 @@ function parseGateAuditValue(value: unknown): GateAudit {
       throw new HardGateError(`Gate audit JSON has an invalid hard_checks.${key} entry.`);
     }
 
+    typed.problem = normalizeAuditQuoteStyle(typed.problem);
+  }
+
+  const optionalChecks: AuditCheckKey[] = ["embedded_template_integrity"];
+  for (const key of optionalChecks) {
+    const item = (hardChecks as Record<string, unknown>)[key];
+    if (item == null) {
+      (hardChecks as Record<string, unknown>)[key] = { pass: true, problem: "" };
+      continue;
+    }
+    if (typeof item !== "object") {
+      throw new HardGateError(`Gate audit JSON has an invalid hard_checks.${key} entry.`);
+    }
+    const typed = item as Record<string, unknown>;
+    if (typeof typed.pass !== "boolean" || typeof typed.problem !== "string") {
+      throw new HardGateError(`Gate audit JSON has an invalid hard_checks.${key} entry.`);
+    }
     typed.problem = normalizeAuditQuoteStyle(typed.problem);
   }
 
@@ -1274,6 +1298,11 @@ function validateStructuralGateChecks(audit: GateAudit): void {
     const detail = audit.hard_checks.protected_span_integrity.problem || "Protected span integrity failed.";
     throw markStructuralHardGateError(new HardGateError(`Protected span integrity failed: ${detail}`));
   }
+  // embedded_template_integrity is intentionally NOT escalated here. We want
+  // it to flow through the normal repair pipeline (patch lane → LLM repair →
+  // rescue model) — the offending spans are usually fixable through a literal
+  // text replacement rather than the unrecoverable placeholder corruption
+  // that protected_span_integrity catches.
 }
 
 function report(options: TranslateOptions, stage: TranslateProgress, message: string): void {
@@ -3219,7 +3248,8 @@ function createSyntheticChunkFailureAudit(message: string): GateAudit {
       numbers_units_logic: { pass: true, problem: "" },
       chinese_punctuation: { pass: true, problem: "" },
       unit_conversion_boundary: { pass: true, problem: "" },
-      protected_span_integrity: { pass: true, problem: "" }
+      protected_span_integrity: { pass: true, problem: "" },
+      embedded_template_integrity: { pass: true, problem: "" }
     },
     must_fix: [`chunk fell back to source content under soft-gate: ${message}`]
   };
@@ -3233,7 +3263,8 @@ function mergeGateAudits(audits: readonly GateAudit[]): GateAudit {
       numbers_units_logic: { pass: true, problem: "" },
       chinese_punctuation: { pass: true, problem: "" },
       unit_conversion_boundary: { pass: true, problem: "" },
-      protected_span_integrity: { pass: true, problem: "" }
+      protected_span_integrity: { pass: true, problem: "" },
+      embedded_template_integrity: { pass: true, problem: "" }
     },
     must_fix: []
   };
@@ -3410,6 +3441,8 @@ function inferRepairFailureType(audit: GateAudit, instruction: string): RepairFa
       return "unit_conversion_boundary";
     case "protected_span_integrity":
       return "protected_span_integrity";
+    case "embedded_template_integrity":
+      return "embedded_template_integrity";
     default:
       return "other";
   }
@@ -5592,7 +5625,8 @@ function buildChunkFailureHardChecks(
         numbers_units_logic: { ...previous.numbers_units_logic },
         chinese_punctuation: { ...previous.chinese_punctuation },
         unit_conversion_boundary: { ...previous.unit_conversion_boundary },
-        protected_span_integrity: { ...previous.protected_span_integrity }
+        protected_span_integrity: { ...previous.protected_span_integrity },
+        embedded_template_integrity: { ...previous.embedded_template_integrity }
       }
     : {
         paragraph_match: { pass: true, problem: "" },
@@ -5600,7 +5634,8 @@ function buildChunkFailureHardChecks(
         numbers_units_logic: { pass: true, problem: "" },
         chinese_punctuation: { pass: true, problem: "" },
         unit_conversion_boundary: { pass: true, problem: "" },
-        protected_span_integrity: { pass: true, problem: "" }
+        protected_span_integrity: { pass: true, problem: "" },
+        embedded_template_integrity: { pass: true, problem: "" }
       };
 
   for (const instruction of mustFix) {

--- a/src/translation-state.ts
+++ b/src/translation-state.ts
@@ -12,7 +12,8 @@ export type AuditCheckKey =
   | "numbers_units_logic"
   | "chinese_punctuation"
   | "unit_conversion_boundary"
-  | "protected_span_integrity";
+  | "protected_span_integrity"
+  | "embedded_template_integrity";
 
 export type HardCheckState = {
   pass: boolean;
@@ -77,6 +78,7 @@ export type RepairFailureType =
   | "chinese_punctuation"
   | "unit_conversion_boundary"
   | "protected_span_integrity"
+  | "embedded_template_integrity"
   | "other";
 
 export type StructuredRepairTarget = {

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -185,6 +185,7 @@ function createAudit(pass: boolean, mustFix: string[] = [], overrides: Partial<G
       chinese_punctuation: { pass, problem: pass ? "" : "punctuation mismatch" },
       unit_conversion_boundary: { pass, problem: pass ? "" : "conversion mismatch" },
       protected_span_integrity: { pass: true, problem: "" },
+      embedded_template_integrity: { pass: true, problem: "" },
       ...overrides
     },
     must_fix: mustFix
@@ -517,7 +518,8 @@ test("parseGateAudit downgrades formatter-only chinese punctuation failures", ()
       numbers_units_logic: { pass: true, problem: "" },
       chinese_punctuation: { pass: false, problem: "“审批疲劳（approval fatigue):”中的半角冒号应改为全角。" },
       unit_conversion_boundary: { pass: true, problem: "" },
-      protected_span_integrity: { pass: true, problem: "" }
+      protected_span_integrity: { pass: true, problem: "" },
+      embedded_template_integrity: { pass: true, problem: "" }
     }),
     repair_targets: [
       {
@@ -561,7 +563,8 @@ test("translateMarkdownArticle reifies chunk failures into executable repair tas
             // path still exercises.
             chinese_punctuation: { pass: false, problem: "第 1 个项目符号句末缺少中文标点。" },
             unit_conversion_boundary: { pass: true, problem: "" },
-            protected_span_integrity: { pass: true, problem: "" }
+            protected_span_integrity: { pass: true, problem: "" },
+            embedded_template_integrity: { pass: true, problem: "" }
           }),
           repair_targets: [
             {
@@ -1914,7 +1917,8 @@ test("translateMarkdownArticle ships first_mention_bilingual cut-piece guidance 
       numbers_units_logic: { pass: true, problem: "" },
       chinese_punctuation: { pass: false, problem: "missing Chinese punctuation" },
       unit_conversion_boundary: { pass: true, problem: "" },
-      protected_span_integrity: { pass: true, problem: "" }
+      protected_span_integrity: { pass: true, problem: "" },
+      embedded_template_integrity: { pass: true, problem: "" }
     }
   );
 
@@ -3276,7 +3280,8 @@ test("translateMarkdownArticle under soft-gate treats first_mention_bilingual-on
     numbers_units_logic: { pass: true, problem: "" },
     chinese_punctuation: { pass: true, problem: "" },
     unit_conversion_boundary: { pass: true, problem: "" },
-    protected_span_integrity: { pass: true, problem: "" }
+    protected_span_integrity: { pass: true, problem: "" },
+    embedded_template_integrity: { pass: true, problem: "" }
   });
 
   const result = await translateMarkdownArticle(source, {
@@ -3317,7 +3322,8 @@ test("translateMarkdownArticle under soft-gate still throws HardGateError when a
     numbers_units_logic: { pass: true, problem: "" },
     chinese_punctuation: { pass: true, problem: "" },
     unit_conversion_boundary: { pass: true, problem: "" },
-    protected_span_integrity: { pass: true, problem: "" }
+    protected_span_integrity: { pass: true, problem: "" },
+    embedded_template_integrity: { pass: true, problem: "" }
   });
 
   await assert.rejects(
@@ -3470,7 +3476,8 @@ test("repair patch lane short-circuits the LLM when structured targets fully cov
               numbers_units_logic: { pass: false, problem: "需补 foobar 小工具的双语锚定。" },
               chinese_punctuation: { pass: true, problem: "" },
               unit_conversion_boundary: { pass: true, problem: "" },
-              protected_span_integrity: { pass: true, problem: "" }
+              protected_span_integrity: { pass: true, problem: "" },
+              embedded_template_integrity: { pass: true, problem: "" }
             },
             must_fix: ["第 1 个项目符号需补 foobar 小工具（foobar widget）首现双语。"],
             repair_targets: [
@@ -3546,7 +3553,8 @@ test("repair patch lane falls through to the LLM when MDZH_REPAIR_PATCH_LANE=fal
               numbers_units_logic: { pass: false, problem: "需补 foobar 小工具双语。" },
               chinese_punctuation: { pass: true, problem: "" },
               unit_conversion_boundary: { pass: true, problem: "" },
-              protected_span_integrity: { pass: true, problem: "" }
+              protected_span_integrity: { pass: true, problem: "" },
+              embedded_template_integrity: { pass: true, problem: "" }
             },
             must_fix: ["第 1 个项目符号需补首现双语。"],
             repair_targets: [
@@ -4097,5 +4105,91 @@ test("MDZH_RESCUE_MODEL=off explicitly disables rescue", async () => {
 
   const rescueEvents = [...sink.events].filter((event) => event.type.startsWith("chunk.rescue"));
   assert.equal(rescueEvents.length, 0, "no rescue events should fire when MDZH_RESCUE_MODEL=off");
+});
+
+test("embedded_template_integrity check failure routes through repair lane and patch fix", async () => {
+  // Audit reports embedded_template_integrity=false with a structured target;
+  // the patch lane should fix it via literal replacement without an LLM repair
+  // call. Validates that the new check participates in the existing repair
+  // pipeline rather than escalating directly to a structural HardGateError.
+  const source = "## API\n\nfoobar 小工具\n";
+
+  const sink = createMemoryTelemetrySink();
+  let auditPasses = 0;
+  let repairCalls = 0;
+
+  const executor: CodexExecutor = {
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(createEmptyAnchorCatalog());
+      }
+      if (isBundledAuditPrompt(prompt, options) || (prompt.includes("只返回 JSON") && prompt.includes("hard_checks"))) {
+        if (auditPasses === 0) {
+          auditPasses += 1;
+          const failingAudit: GateAudit = {
+            hard_checks: {
+              paragraph_match: { pass: true, problem: "" },
+              first_mention_bilingual: { pass: true, problem: "" },
+              numbers_units_logic: { pass: true, problem: "" },
+              chinese_punctuation: { pass: true, problem: "" },
+              unit_conversion_boundary: { pass: true, problem: "" },
+              protected_span_integrity: { pass: true, problem: "" },
+              embedded_template_integrity: { pass: false, problem: "字段名 foobar 小工具 应字面保留为 foobar widget。" }
+            },
+            must_fix: ["第 1 段需保留原文字面 foobar widget，不要改为 foobar 小工具。"],
+            repair_targets: [
+              {
+                location: "第 1 段",
+                kind: "block",
+                currentText: "foobar 小工具",
+                targetText: "foobar widget",
+                english: "foobar widget"
+              }
+            ]
+          };
+          return createExecResult(wrapAuditForSegments(prompt, failingAudit));
+        }
+        return createExecResult(wrapAuditForSegments(prompt, createAudit(true)));
+      }
+      if (options.outputSchema && prompt.includes("### BLOCK")) {
+        const blockCount = (prompt.match(/^### BLOCK \d+ \([^)]+\)$/gm) ?? []).length || 1;
+        return createExecResult(JSON.stringify({ blocks: Array.from({ length: blockCount }, () => "foobar 小工具") }));
+      }
+      if (prompt.includes("【must_fix】")) {
+        repairCalls += 1;
+        return createExecResult("foobar widget\n");
+      }
+      const current = extractPromptSection(prompt, "【当前译文】");
+      if (current !== null) {
+        return createExecResult(current);
+      }
+      return createExecResult("foobar 小工具\n");
+    }
+  };
+
+  await translateMarkdownArticle(source, {
+    executor,
+    formatter: async (markdown) => markdown,
+    softGate: true,
+    telemetry: sink
+  });
+
+  // Patch lane should have applied the structured target at least once. We
+  // don't assert repairCalls === 0 because materializeFailedHardCheckProblems
+  // injects a sentinel must_fix for the failing check itself (which has no
+  // structuredTarget), so the LLM repair lane still fires for that companion
+  // task. The point of the test is that embedded_template_integrity failures
+  // flow through the existing repair pipeline (patch lane + LLM) rather than
+  // immediately bubbling as a structural HardGateError.
+  const repairCycles = [...sink.events].filter((event) => event.type === "repair.cycle");
+  assert.ok(repairCycles.length >= 1, "expected at least one repair.cycle event");
+  const patchEvents = [...sink.events].filter((event) => event.type === "repair.patch");
+  assert.ok(patchEvents.length >= 1, "expected at least one repair.patch event");
+  const applied = patchEvents.reduce(
+    (sum, event) => sum + Number((event.meta as Record<string, unknown>).applied ?? 0),
+    0
+  );
+  assert.ok(applied >= 1, `expected at least one structured patch to apply, got ${applied}`);
+  void repairCalls;
 });
 

--- a/test/translation-state.test.ts
+++ b/test/translation-state.test.ts
@@ -74,7 +74,8 @@ test("translation state tracks first-occurrence anchors and repeat anchors acros
       numbers_units_logic: { pass: true, problem: "" },
       chinese_punctuation: { pass: true, problem: "" },
       unit_conversion_boundary: { pass: true, problem: "" },
-      protected_span_integrity: { pass: true, problem: "" }
+      protected_span_integrity: { pass: true, problem: "" },
+      embedded_template_integrity: { pass: true, problem: "" }
     },
     repairTasks: [],
     rawMustFix: []
@@ -119,7 +120,8 @@ test("translation state keeps repair tasks bound to the target segment only", ()
       numbers_units_logic: { pass: true, problem: "" },
       chinese_punctuation: { pass: true, problem: "" },
       unit_conversion_boundary: { pass: true, problem: "" },
-      protected_span_integrity: { pass: true, problem: "" }
+      protected_span_integrity: { pass: true, problem: "" },
+      embedded_template_integrity: { pass: true, problem: "" }
     },
     repairTasks: [
       {
@@ -179,7 +181,8 @@ test("translation state carries sentence-local repair constraints into the promp
       numbers_units_logic: { pass: true, problem: "" },
       chinese_punctuation: { pass: true, problem: "" },
       unit_conversion_boundary: { pass: true, problem: "" },
-      protected_span_integrity: { pass: true, problem: "" }
+      protected_span_integrity: { pass: true, problem: "" },
+      embedded_template_integrity: { pass: true, problem: "" }
     },
     repairTasks: [
       {
@@ -453,7 +456,8 @@ test("translation state links pending repairs to matching analysis IR plans", ()
       numbers_units_logic: { pass: true, problem: "" },
       chinese_punctuation: { pass: true, problem: "" },
       unit_conversion_boundary: { pass: true, problem: "" },
-      protected_span_integrity: { pass: true, problem: "" }
+      protected_span_integrity: { pass: true, problem: "" },
+      embedded_template_integrity: { pass: true, problem: "" }
     },
     repairTasks: [
       {
@@ -508,7 +512,8 @@ test("translation state synthesizes local fallback anchors from bound IR targets
       numbers_units_logic: { pass: true, problem: "" },
       chinese_punctuation: { pass: true, problem: "" },
       unit_conversion_boundary: { pass: true, problem: "" },
-      protected_span_integrity: { pass: true, problem: "" }
+      protected_span_integrity: { pass: true, problem: "" },
+      embedded_template_integrity: { pass: true, problem: "" }
     },
     repairTasks: [
       {
@@ -584,7 +589,8 @@ test("translation state synthesizes a local fallback anchor for a longer list-it
       },
       chinese_punctuation: { pass: true, problem: "" },
       unit_conversion_boundary: { pass: true, problem: "" },
-      protected_span_integrity: { pass: true, problem: "" }
+      protected_span_integrity: { pass: true, problem: "" },
+      embedded_template_integrity: { pass: true, problem: "" }
     },
     repairTasks: [
       {
@@ -637,7 +643,8 @@ test("translation state synthesizes a local fallback anchor from a structured re
       numbers_units_logic: { pass: true, problem: "" },
       chinese_punctuation: { pass: true, problem: "" },
       unit_conversion_boundary: { pass: true, problem: "" },
-      protected_span_integrity: { pass: true, problem: "" }
+      protected_span_integrity: { pass: true, problem: "" },
+      embedded_template_integrity: { pass: true, problem: "" }
     },
     repairTasks: [
       {
@@ -714,7 +721,8 @@ test("translation state reconciles a shorter family local fallback target to an 
       numbers_units_logic: { pass: true, problem: "" },
       chinese_punctuation: { pass: true, problem: "" },
       unit_conversion_boundary: { pass: true, problem: "" },
-      protected_span_integrity: { pass: true, problem: "" }
+      protected_span_integrity: { pass: true, problem: "" },
+      embedded_template_integrity: { pass: true, problem: "" }
     },
     repairTasks: [
       {
@@ -835,7 +843,8 @@ test("translation state synthesizes a local fallback anchor for an inline concep
       numbers_units_logic: { pass: true, problem: "" },
       chinese_punctuation: { pass: true, problem: "" },
       unit_conversion_boundary: { pass: true, problem: "" },
-      protected_span_integrity: { pass: true, problem: "" }
+      protected_span_integrity: { pass: true, problem: "" },
+      embedded_template_integrity: { pass: true, problem: "" }
     },
     repairTasks: [
       {
@@ -1047,7 +1056,8 @@ test("translation state synthesizes local fallback anchors for heading-like conf
       numbers_units_logic: { pass: true, problem: "" },
       chinese_punctuation: { pass: true, problem: "" },
       unit_conversion_boundary: { pass: true, problem: "" },
-      protected_span_integrity: { pass: true, problem: "" }
+      protected_span_integrity: { pass: true, problem: "" },
+      embedded_template_integrity: { pass: true, problem: "" }
     },
     repairTasks: [
       {
@@ -1672,7 +1682,8 @@ test("translation state allows bare repeat text for established english-primary 
       numbers_units_logic: { pass: true, problem: "" },
       chinese_punctuation: { pass: true, problem: "" },
       unit_conversion_boundary: { pass: true, problem: "" },
-      protected_span_integrity: { pass: true, problem: "" }
+      protected_span_integrity: { pass: true, problem: "" },
+      embedded_template_integrity: { pass: true, problem: "" }
     },
     repairTasks: [],
     rawMustFix: []
@@ -1745,7 +1756,8 @@ test("translation state does not treat a singular anchor as mentioned by a plura
       numbers_units_logic: { pass: true, problem: "" },
       chinese_punctuation: { pass: true, problem: "" },
       unit_conversion_boundary: { pass: true, problem: "" },
-      protected_span_integrity: { pass: true, problem: "" }
+      protected_span_integrity: { pass: true, problem: "" },
+      embedded_template_integrity: { pass: true, problem: "" }
     },
     repairTasks: [],
     rawMustFix: []


### PR DESCRIPTION
## Summary

新增第 7 项 hard check：`embedded_template_integrity` —— 专门覆盖「正文里嵌入的示例性 Markdown 模板 / 类型签名 / 伪标题」被模型误译的失败模式。

## Why

最近 spec-driven-development 长文翻译撞了三处类似失败（chunks 7 / 8 / 10），其中典型是：
- `Response: { photoId: string, success: boolean }` 里的 `string` 被翻成「字符串」
- 字段名 `photoId` / `fileName` 被翻成中文
- 伪标题 `**# Feature Specification**` 的英文部分被翻

`protected_span_integrity` 只看占位符；`paragraph_match` 只看段落数。这类伪结构没人管。

## 设计选择

- **不当结构错立即升级**：不进入 `validateStructuralGateChecks`。最常见的字面替换可由 Phase 2B 差分 patch lane 直接修复，进入正常 repair 流程后失败再走 rescue 模型。
- **向后兼容**：`parseGateAuditValue` 把新字段放进 `optionalChecks`，旧 audit 响应缺该字段时默认 `{ pass: true, problem: "" }`。
- **prompt 详细举例**：审校 prompt 列了 `**# Feature Specification**` / `User { id: string, email: string }` / `POST /api/photos/upload` 等真实样例；明确 `[Feature Name]` 这类方括号占位允许译成中文。

## Verification

- `npm run verify` 通过：278 单元 + typecheck + build。
- 新增端到端测试：embedded_template_integrity=false + 结构化 target → 走 repair.cycle + 至少一次 patch.applied。
- 277 个现存测试通过同步 fixture 字段后继续绿。

## Notes

- 这次失败的 chunks 8 / 10 是列表合并 / 内容缺失，本 PR 不覆盖（继续走 `paragraph_match` 既有路径 + rescue 模型兜底）。
- 重跑 spec-driven-development 文章预期 chunk 7 的类型签名失败会被新 check 在 audit 阶段抓到、由 patch lane 直接修。

🤖 Generated with [Claude Code](https://claude.com/claude-code)