### PR TITLE
fix: ≥3 list groups 强制拆 segment

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -8485,6 +8485,7 @@ function formatBundledAuditSegments(draftedSegments: readonly DraftedSegmentStat
 const MIN_SEGMENT_HEADING_SPLIT_CHARACTERS = 2600;
 const MIN_COMPLEX_SEGMENT_CHARACTERS = 160;
 const COMPLEX_SEGMENT_SCORE_THRESHOLD = 4;
+const MIN_REPEATED_LIST_GROUPS_TO_SPLIT = 3;
 
 export function splitProtectedChunkSegments(
   source: string,
@@ -8717,6 +8718,17 @@ function shouldSplitPendingByComplexity(
     return false;
   }
 
+  // Repeated list-group cut: when the pending segment already contains
+  // ≥ MIN_REPEATED_LIST_GROUPS_TO_SPLIT distinct list blocks (typically a
+  // **Step N:** / **Heading:** lead-in followed by bullets pattern), force a
+  // split before another list arrives. Empirically the model loses track of
+  // "which list group am I translating?" once 3+ similar groups co-occur in
+  // one segment — it duplicates prior bullets at the segment tail. Cutting
+  // earlier keeps each segment focused on one list group.
+  if (incomingKind === "list" && countListBlocks(pending) >= MIN_REPEATED_LIST_GROUPS_TO_SPLIT) {
+    return true;
+  }
+
   const pendingChars = measureRawBlocks(pending);
   if (pendingChars < MIN_COMPLEX_SEGMENT_CHARACTERS) {
     return false;
@@ -8724,6 +8736,16 @@ function shouldSplitPendingByComplexity(
 
   const complexityScore = pending.reduce((total, block) => total + scoreSegmentComplexityBlock(block.content), 0);
   return complexityScore >= COMPLEX_SEGMENT_SCORE_THRESHOLD;
+}
+
+function countListBlocks(blocks: ReadonlyArray<{ content: string }>): number {
+  let count = 0;
+  for (const block of blocks) {
+    if (classifyPromptBlockKind(block.content) === "list") {
+      count += 1;
+    }
+  }
+  return count;
 }
 
 function scoreSegmentComplexityBlock(content: string): number {

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -4273,3 +4273,81 @@ test("dedupDraftDuplicateTailListItems trims numbered list duplicates too", () =
   assert.equal(items.length, 3);
 });
 
+test("splitProtectedChunkSegments cuts a chunk when ≥3 list groups co-occur in one pending segment", async () => {
+  // Mirror the spec-driven §How To Implement pattern: emphasis-headed list
+  // groups stacked together. Three list groups in the same segment is the
+  // exact configuration that empirically triggers tail-bullet duplication.
+  const { splitProtectedChunkSegments } = await import("../src/translate.js") as {
+    splitProtectedChunkSegments: (
+      source: string,
+      spanIndex: Map<string, unknown>
+    ) => Array<{ kind: string; source: string }>;
+  };
+
+  const source = [
+    "**Step 1: Spec**",
+    "",
+    "Some lead-in.",
+    "",
+    "- list-1 a",
+    "- list-1 b",
+    "- list-1 c",
+    "",
+    "**Step 2: Stakeholders**",
+    "",
+    "More lead-in.",
+    "",
+    "- list-2 a",
+    "- list-2 b",
+    "",
+    "**Step 3: Tasks**",
+    "",
+    "Task lead-in.",
+    "",
+    "- list-3 a",
+    "- list-3 b",
+    "- list-3 c",
+    "- list-3 d",
+    "",
+    "**Step 4: Tests**",
+    "",
+    "Test lead-in.",
+    "",
+    "- list-4 a",
+    "- list-4 b",
+    ""
+  ].join("\n");
+
+  const segments = splitProtectedChunkSegments(source, new Map());
+  const translatable = segments.filter((segment) => segment.kind === "translatable");
+  assert.ok(
+    translatable.length >= 2,
+    `expected ≥ 2 translatable segments after list-density split, got ${translatable.length}`
+  );
+});
+
+test("splitProtectedChunkSegments leaves a single-list section in a single segment", async () => {
+  // A single list group with a small lead-in should not trip any of the
+  // splitter heuristics. Acts as a sanity floor: the new ≥3-list cut must
+  // not regress the simple case down to multiple segments.
+  const { splitProtectedChunkSegments } = await import("../src/translate.js") as {
+    splitProtectedChunkSegments: (
+      source: string,
+      spanIndex: Map<string, unknown>
+    ) => Array<{ kind: string; source: string }>;
+  };
+
+  const source = [
+    "Lead-in.",
+    "",
+    "- a",
+    "- b",
+    "- c",
+    ""
+  ].join("\n");
+
+  const segments = splitProtectedChunkSegments(source, new Map());
+  const translatable = segments.filter((segment) => segment.kind === "translatable");
+  assert.equal(translatable.length, 1, "single list group should remain in a single segment");
+});
+


### PR DESCRIPTION
## Summary

Resilience plan §3.1 第一条最小改动版本：在 `shouldSplitPendingByComplexity` 加一道独立旁路——pending segment 中累计 ≥3 个 list block 时，下一个 list block 强制开新 segment。

## Why

`docs/translation-resilience-plan.md` 里诊断的根因之一：spec-driven 长文失败 chunks（9 / 12 / 13 / 14）都是「emphasis-headed list group」连续 ≥ 3 组挤进同一 segment 的形态。现有 size + score 阈值对这一信号不敏感（emphasis+list = 2 分/组），整段挤进一起后模型在尾部"凑齐"前序列表，触发末尾重复追加。

新规则只针对一个**通用信号**（同 segment 内 list 块数累积），不对单篇文章硬编码。

## Verification

- 全套 285 单元 + typecheck + build 全绿
- 现存 283 项无回归
- 新增 2 项测试：3+ list 强制拆 / 单 list 不拆（防回归）

## Notes

- 阈值常数 `MIN_REPEATED_LIST_GROUPS_TO_SPLIT = 3` 命名好，便于后续 fixture 验证后微调
- §3.2 结构骨架对齐校验上线后，本规则与现有 dedup 函数会一同评估是否收编进通用机制（不在本 PR 范围）

🤖 Generated with [Claude Code](https://claude.com/claude-code)