### PR TITLE
fix: list 组拆 segment 阈值 3→2（调优）

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -8485,7 +8485,13 @@ function formatBundledAuditSegments(draftedSegments: readonly DraftedSegmentStat
 const MIN_SEGMENT_HEADING_SPLIT_CHARACTERS = 2600;
 const MIN_COMPLEX_SEGMENT_CHARACTERS = 160;
 const COMPLEX_SEGMENT_SCORE_THRESHOLD = 4;
-const MIN_REPEATED_LIST_GROUPS_TO_SPLIT = 3;
+// Empirically tuned on spec-driven §How To Implement (chunks 9 / 12 / 14):
+// threshold = 3 only cut into 2 segments which still left 3 list groups in
+// one segment, model duplicated tail. Lowering to 2 cuts every time a third
+// list arrives — segment 2 of those failing chunks now splits into ≥ 2
+// pieces, and each piece carries at most 2 list groups (well within the
+// model's "track which list I'm on" capacity).
+const MIN_REPEATED_LIST_GROUPS_TO_SPLIT = 2;
 
 export function splitProtectedChunkSegments(
   source: string,


### PR DESCRIPTION
## Summary

PR #97 上线 threshold=3 后重跑 spec-driven 仍撞同样的「译文末尾重复追加 list」失败。chunk 9 拆成 2 段还是不够细——segment 2 仍含 3 组 list，模型在末尾再吐一遍。

降到 2：第 3 个 list 群一进就拆。chunks 9 / 12 / 13 / 14 那类形态强制拆成更小 segments，每段最多 2 个 list 群。

## Verification

- 285 单元 + typecheck + build 全绿
- 4-list 拆 segment 测试反而拆得更多（threshold=2 更激进）
- 单 list 不拆仍保留

## Notes

- resilience plan §3.1 第一条的**实测调优**，不超出该方向范围
- 阈值常数命名保留，后续若不够细可继续下调

🤖 Generated with [Claude Code](https://claude.com/claude-code)