### PR TITLE
docs: 收尾 §3.1：补 small-segment list self-dup fixture + 更新 plan

### DIFF
--- a/docs/translation-resilience-plan.md
+++ b/docs/translation-resilience-plan.md
@@ -107,9 +107,9 @@ function alignSkeletons(source: StructuralSkeleton, draft: StructuralSkeleton):
 
 不要平行做。一次一个。
 
-1. **本 PR**（已开始）：fixtures 落库 + 这份设计文档。**不动 src/**。让方向先沉淀下来，避免又一次"边写代码边改方向"。
-2. **下一个 PR**（推荐方向 3.1）：复杂度指标加列表组维度 + JSON-blocks lane 强制路由。**单一改动，单一目标**：让 chunks 9 / 12 / 13 / 14 那些 fixture 在 short smoke 里通过率上升 ≥ 1 档。
-3. **再下一个 PR**（推荐方向 3.2）：结构骨架对齐校验。同时**清理**老 dedup 函数（验证完后删）。
+1. **PR #96**（已合）：fixtures 落库 + 这份设计文档。
+2. **PR #97 / #98**（已合，§3.1 第一条）：复杂度指标加「连续相似 list 群」信号，threshold 从 3 调到 2。spec-driven 长文 chunk 9 由 2 段拆成 3 段——但**实测发现 1 导语+2 bullets 的极小 segment 仍被模型自我重复**。结论：缩小 segment 边际收益已触底，单纯继续拆没意义（小段 list self-duplication fixture 已补，见 §5）。
+3. **下一个 PR**（推荐方向 3.2）：结构骨架对齐校验。直接比对 source / draft 的 list 项数、段数等**结构信号**，不依赖文本相似度。能直接覆盖小段 self-duplication 这类无法靠 n-gram 相似度判定的情形。同时**收编**老 dedup 函数（PR #95）+ embedded_template_integrity（PR #94）+ list 群拆 segment（PR #97/#98）的 patch 范围。
 4. **观察期**（不做新功能）：跑两三轮真实长文 smoke，看 long-tail 失败分布是否变了；如果是同类问题反复出现，回看 §3.1/3.2 是否真到位；如果是新模式，先加 fixture，不要立即写代码。
 
 ## 5. 已合并 PR 的处置建议

--- a/test/fixtures/resilience/small-segment-list-self-duplication.md
+++ b/test/fixtures/resilience/small-segment-list-self-duplication.md
@@ -1,0 +1,21 @@
+---
+title: "small-segment list self-duplication (chunks 9 segment 2 in spec5)"
+notes:
+  - failure: 即使 segment 极小（1 段导语 + 2 条 bullets），模型仍然在末尾追加重复的 2 条 bullets，把列表数变成 4 条
+  - source: spec-driven §How To Implement，threshold=2 拆出来的小 segment
+  - existing_remedies_did_not_catch:
+      - 缩小 segment（PR #97/#98 把 chunk 9 从 2 段拆成 3 段）→ segment 2 已经只有 1 导语 + 2 bullets，仍失败
+      - dedupDraftDuplicateTailListItems（PR #95）→ 应能匹配 source 2 / draft 4 的情况，但实测此次未生效；候选原因：duplicate bullets 的译文措辞每次略不同，draftBlocksLookLikeDuplicate 的 55% n-gram 阈值未达
+      - rescue 模型 gpt-5.5 → 也同样追加
+  - meta_signal: 这是 LLM 在「小 list followed by self」模式上的固有倾向，单纯靠继续缩 segment / 加 dedup 无法根治
+  - resilient_direction:
+      - resilience plan §3.2 结构骨架对齐：parseStructure 在 source / draft 比对时直接看 list 项数，不依赖文本相似度。source 2 vs draft 4 → 强信号，砍尾 / 报 audit fail
+      - 收编后 dedupDraftDuplicateTailListItems / dedupDraftDuplicateTailBlocks / dedupDraftDuplicateTailSentences 可一并删除
+---
+**Step 5: Code Becomes Implementation, Not Discovery**
+
+When you code from a spec, you are not discovering the design mid-project. You are simply implementing what has already been decided. This means:
+
+- No debates about architecture during coding (already settled in spec)
+
+- No surprise features requested mid-sprint (spec is locked)


### PR DESCRIPTION
## Summary

PR #97/#98 上线后实测：spec-driven §How To Implement chunk 9 由 2 段拆成 3 段，但 segment 2（1 导语 + 2 bullets 的极小段）仍被模型自我重复，列表变成 4 条；rescue 也复现。说明缩 segment 边际收益触底。

按 resilience plan §3.3 收尾本方向：

- 新增 `test/fixtures/resilience/small-segment-list-self-duplication.md` 记录 LLM 在「小 list followed by self」模式上的固有失败
- 更新 `docs/translation-resilience-plan.md §4`：标注已完成步骤、明确下一步转向 §3.2 结构骨架对齐校验

## Verification

- 不动 src/，285 单元 + typecheck + build 全绿
- 仅文档与 fixture 改动

🤖 Generated with [Claude Code](https://claude.com/claude-code)