### PR TITLE
fix: 把 skeleton aligner 挪到 reprotect 之后 + placeholder 守恒守卫

### DIFF
--- a/src/structure-skeleton.ts
+++ b/src/structure-skeleton.ts
@@ -178,6 +178,16 @@ export function planListOverflowTrim(
 }
 
 const RAW_BLOCK_SEPARATOR = "\n\n";
+const PROTECTED_PLACEHOLDER_PATTERN = /@@MDZH_[A-Z_]+_\d{4}@@/g;
+
+function countProtectedPlaceholders(text: string): number {
+  PROTECTED_PLACEHOLDER_PATTERN.lastIndex = 0;
+  let count = 0;
+  while (PROTECTED_PLACEHOLDER_PATTERN.exec(text) !== null) {
+    count += 1;
+  }
+  return count;
+}
 
 function rawBlocksOf(text: string): string[] {
   if (!text) {
@@ -264,19 +274,33 @@ export function alignDraftToSourceSkeleton(source: string, draft: string): strin
   if (!source || !draft) {
     return draft;
   }
+  // Placeholder safety: when this aligner runs after reprotectMarkdownSpans,
+  // the body carries `@@MDZH_*@@` placeholders for protected spans (links,
+  // image destinations, autolinks, html attributes). Trimming a tail block
+  // or list item that contains a placeholder would silently delete the
+  // span and trip the downstream `protected_span_integrity` hard check.
+  // Guard each trim with a count check and revert if the trim would change
+  // the placeholder count.
+  const draftPlaceholderCount = countProtectedPlaceholders(draft);
   let body = draft;
   let sourceSkeleton = parseStructure(source);
   let draftSkeleton = parseStructure(body);
 
   const tailPlan = planTailTrim(sourceSkeleton, draftSkeleton);
   if (tailPlan) {
-    body = applyTailTrim(body, draftSkeleton, tailPlan.dropFrom);
-    draftSkeleton = parseStructure(body);
+    const candidate = applyTailTrim(body, draftSkeleton, tailPlan.dropFrom);
+    if (countProtectedPlaceholders(candidate) === draftPlaceholderCount) {
+      body = candidate;
+      draftSkeleton = parseStructure(body);
+    }
   }
 
   const overflowPlan = planListOverflowTrim(sourceSkeleton, draftSkeleton);
   if (overflowPlan) {
-    body = applyListItemTrim(body, overflowPlan.blockIndex, overflowPlan.keepItems);
+    const candidate = applyListItemTrim(body, overflowPlan.blockIndex, overflowPlan.keepItems);
+    if (countProtectedPlaceholders(candidate) === draftPlaceholderCount) {
+      body = candidate;
+    }
   }
   void sourceSkeleton;
   return body;

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -6693,14 +6693,19 @@ async function translateProtectedSegment(
     );
   }
   threadId = draftResult.threadId;
-  const dedupedDraftText = alignDraftToSourceSkeleton(
+  // Note: alignDraftToSourceSkeleton previously ran here (before the
+  // anchor / plan / restore normalization chain). Empirical debug runs
+  // showed it never fired on real failures because subsequent normalizers
+  // — most likely injectPlannedAnchorText / applyBlockPlanTargets — were
+  // duplicating list items AFTER alignment. Aligner is moved to right
+  // after reprotectMarkdownSpans so it sees the same body audit will see.
+  // The dedupDraftDuplicate* family stays here as a pre-normalization
+  // safety net for the model's own immediate echoes.
+  const dedupedDraftText = dedupDraftDuplicateTailListItems(
     protectedSource,
-    dedupDraftDuplicateTailListItems(
+    dedupDraftDuplicateTailSentences(
       protectedSource,
-      dedupDraftDuplicateTailSentences(
-        protectedSource,
-        dedupDraftDuplicateTailBlocks(protectedSource, draftResult.text)
-      )
+      dedupDraftDuplicateTailBlocks(protectedSource, draftResult.text)
     )
   );
   const normalizedDraftText = normalizeSegmentAnchorText(
@@ -6762,7 +6767,15 @@ async function translateProtectedSegment(
       normalizeMarkdownLinkLabelWhitespace(restoredExampleTokenDraftText)
     )
   );
-  const canonicalProtectedBody = reprotectMarkdownSpans(normalizedDraftSurfaceText, combinedSpans);
+  const reprotectedBody = reprotectMarkdownSpans(normalizedDraftSurfaceText, combinedSpans);
+  // Final structural skeleton alignment: now that the body has been through
+  // anchor / plan / inline-code / autolink / etc. normalization and is
+  // reprotected, compare it to the source skeleton and trim any list-item
+  // overflow / tail-block duplication that was injected (or left untouched)
+  // by intermediate steps. The aligner refuses to trim if doing so would
+  // change the protected-placeholder count, so this is safe vs the
+  // protected_span_integrity hard check.
+  const canonicalProtectedBody = alignDraftToSourceSkeleton(protectedSource, reprotectedBody);
   const restoredBody = restoreMarkdownSpans(canonicalProtectedBody, combinedSpans);
   applySegmentDraft(context.state, segmentId, {
     protectedSource,
@@ -7517,14 +7530,15 @@ async function repairDraftedSegment(
     if (repairResult.threadId) {
       draftedSegment.threadId = repairResult.threadId;
     }
-    const dedupedRepairText = alignDraftToSourceSkeleton(
+    // alignDraftToSourceSkeleton moved to after reprotectMarkdownSpans below
+    // (same reason as in translateProtectedSegment): pre-normalization the
+    // body still has anchors / plans / blocks to apply, which can themselves
+    // duplicate list items.
+    const dedupedRepairText = dedupDraftDuplicateTailListItems(
       draftedSegment.protectedSource,
-      dedupDraftDuplicateTailListItems(
+      dedupDraftDuplicateTailSentences(
         draftedSegment.protectedSource,
-        dedupDraftDuplicateTailSentences(
-          draftedSegment.protectedSource,
-          dedupDraftDuplicateTailBlocks(draftedSegment.protectedSource, repairResult.text)
-        )
+        dedupDraftDuplicateTailBlocks(draftedSegment.protectedSource, repairResult.text)
       )
     );
     const normalizedRepairText = normalizeSegmentAnchorText(
@@ -7591,9 +7605,17 @@ async function repairDraftedSegment(
         normalizeMarkdownLinkLabelWhitespace(restoredExampleTokenRepairText)
       )
     );
-    draftedSegment.protectedBody = reprotectMarkdownSpans(
+    const reprotectedRepairBody = reprotectMarkdownSpans(
       normalizedRepairSurfaceText,
       draftedSegment.spans
+    );
+    // Final structural skeleton alignment for repair output (mirror of draft
+    // path). Trims any list / tail-block overflow injected by the post-repair
+    // normalization chain. Placeholder-count guard prevents protected_span
+    // breakage.
+    draftedSegment.protectedBody = alignDraftToSourceSkeleton(
+      draftedSegment.protectedSource,
+      reprotectedRepairBody
     );
     draftedSegment.restoredBody = restoreMarkdownSpans(draftedSegment.protectedBody, draftedSegment.spans);
     applyRepairResult(context.state, draftedSegment.segmentId, taskBatch.map((task) => task.id), {

--- a/test/structure-skeleton.test.ts
+++ b/test/structure-skeleton.test.ts
@@ -173,3 +173,56 @@ test("alignDraftToSourceSkeleton tolerates empty inputs", () => {
   assert.equal(alignDraftToSourceSkeleton("", "anything"), "anything");
   assert.equal(alignDraftToSourceSkeleton("anything", ""), "");
 });
+
+test("alignDraftToSourceSkeleton refuses to trim when doing so would drop a protected placeholder", () => {
+  // Source has 1 list item with a protected link placeholder. Draft has 4
+  // list items, with placeholder copies in the duplicates. Trimming the
+  // duplicates would also drop placeholder occurrences and break the
+  // protected_span_integrity hard check; aligner must abort the trim.
+  const source = [
+    "Lead-in.",
+    "",
+    "- See [doc](@@MDZH_LINK_DESTINATION_0001@@)",
+    ""
+  ].join("\n");
+  const draft = [
+    "导语。",
+    "",
+    "- 见 [文档](@@MDZH_LINK_DESTINATION_0001@@)",
+    "- 见 [文档](@@MDZH_LINK_DESTINATION_0001@@)",
+    "- 见 [文档](@@MDZH_LINK_DESTINATION_0001@@)",
+    "- 见 [文档](@@MDZH_LINK_DESTINATION_0001@@)",
+    ""
+  ].join("\n");
+
+  const aligned = alignDraftToSourceSkeleton(source, draft);
+  assert.equal(aligned, draft, "aligner must keep draft untouched when trim would drop placeholders");
+});
+
+test("alignDraftToSourceSkeleton trims when no placeholders are touched", () => {
+  // Draft duplicates plain bullets without placeholders; source's only
+  // placeholder lives in the lead-in paragraph. Trim should fire because
+  // the trimmed bullets carry no placeholders.
+  const source = [
+    "Lead-in with a [link](@@MDZH_LINK_DESTINATION_0001@@).",
+    "",
+    "- alpha",
+    "- bravo",
+    ""
+  ].join("\n");
+  const draft = [
+    "导语带 [链接](@@MDZH_LINK_DESTINATION_0001@@)。",
+    "",
+    "- 甲",
+    "- 乙",
+    "- 甲",
+    "- 乙",
+    ""
+  ].join("\n");
+
+  const aligned = alignDraftToSourceSkeleton(source, draft);
+  const items = aligned.split("\n").filter((line) => /^\s*-\s/.test(line));
+  assert.equal(items.length, 2);
+  const placeholderCount = (aligned.match(/@@MDZH_LINK_DESTINATION_0001@@/g) ?? []).length;
+  assert.equal(placeholderCount, 1);
+});


### PR DESCRIPTION
## Summary

PR #100 上线后实测 root cause：178 次 align 调用全部 0 trim，但 audit 仍报 list 重复——aligner 看到的 draft 没问题，**之后 12 道 normalization** 在 reprotect 前塞入了重复。

修法：
- aligner 调用从 dedup 链末尾挪到 `reprotectMarkdownSpans` 之后，让它看到与 audit 同款的 canonicalProtectedBody
- 加 placeholder 计数守恒守卫：trim 若会丢掉 `@@MDZH_*@@` 占位符（含受保护 link/image 的 bullet），拒绝 trim、原样返回
- 保留 `dedupDraftDuplicateTail*` 在原位置作为 LLM 即时回吐的早期防线

## Verification

- 298 单元 + typecheck + build 全绿
- 新增 2 项 placeholder 守恒单元

## Notes

预期 spec-driven chunks 4/9/12/14 那类「post-normalization list 重复」由这次的 aligner 接住。

🤖 Generated with [Claude Code](https://claude.com/claude-code)