### PR TITLE
fix: parseStructure 合并连续 list 块（chunk 13 root cause）

### DIFF
--- a/src/structure-skeleton.ts
+++ b/src/structure-skeleton.ts
@@ -56,29 +56,53 @@ function countListItems(content: string): number {
 
 /**
  * Parse a markdown body into a structural skeleton: a flat sequence of
- * blocks with kind + size info. Splits on blank-line boundaries (matching
- * `splitPromptBlocks`'s convention) so blocks like a list group + its
- * surrounding prose stay distinguishable.
+ * blocks with kind + size info. Splits on blank-line boundaries first
+ * (matching `splitPromptBlocks`'s convention), then coalesces runs of
+ * adjacent list-block fragments into a single logical list block.
+ *
+ * The coalescing step matters because the spec-driven fixture (and other
+ * Medium-flavor exports) writes bullets with blank lines between each item:
+ *
+ *     - Specs are version-controlled
+ *
+ *     - Linked to code that implements them
+ *
+ *     - Every PR references a spec
+ *
+ * Naive blank-line splitting yields 3 separate `list(1)` blocks, which makes
+ * "an extra bullet appeared" indistinguishable from "an extra paragraph
+ * appeared at the tail". Coalescing produces one `list(3)` block instead,
+ * so list count overflow gets detected directly and tail-block trimming
+ * doesn't over-eagerly remove unrelated trailing prose.
  */
 export function parseStructure(text: string): StructuralSkeleton {
   if (!text || !text.trim()) {
     return [];
   }
-  const blocks: StructuralBlock[] = [];
   const rawBlocks = text
     .split(/\n{2,}/)
     .map((block) => block.replace(/\s+$/, ""))
     .filter((block) => block.trim().length > 0);
+
+  const blocks: StructuralBlock[] = [];
   for (const raw of rawBlocks) {
     const trimmed = raw.trim();
     const kind = classifyBlockKind(trimmed);
+    const items = kind === "list" ? countListItems(trimmed) : 0;
+    const lastBlock = blocks[blocks.length - 1];
+    if (kind === "list" && lastBlock?.kind === "list") {
+      lastBlock.listItemCount = (lastBlock.listItemCount ?? 0) + items;
+      lastBlock.charLen += trimmed.length;
+      lastBlock.lineCount += trimmed.split(/\r?\n/).length;
+      continue;
+    }
     const block: StructuralBlock = {
       kind,
       charLen: trimmed.length,
       lineCount: trimmed.split(/\r?\n/).length
     };
     if (kind === "list") {
-      block.listItemCount = countListItems(trimmed);
+      block.listItemCount = items;
     }
     blocks.push(block);
   }
@@ -177,7 +201,6 @@ export function planListOverflowTrim(
   return null;
 }
 
-const RAW_BLOCK_SEPARATOR = "\n\n";
 const PROTECTED_PLACEHOLDER_PATTERN = /@@MDZH_[A-Z_]+_\d{4}@@/g;
 
 function countProtectedPlaceholders(text: string): number {
@@ -189,78 +212,110 @@ function countProtectedPlaceholders(text: string): number {
   return count;
 }
 
-function rawBlocksOf(text: string): string[] {
-  if (!text) {
-    return [];
+type LogicalBlockRange = {
+  /** index of the logical block in the skeleton (parseStructure output) */
+  index: number;
+  kind: StructuralBlockKind;
+  startLine: number;
+  /** inclusive */
+  endLine: number;
+};
+
+/**
+ * Walk lines and produce per-logical-block line ranges. Consecutive list
+ * runs (with blank lines between them) get coalesced into one logical block,
+ * matching parseStructure's coalescing rule. Used by the tail / overflow
+ * trim helpers so they operate on the same boundaries the skeleton sees.
+ */
+function findLogicalBlockRanges(text: string): LogicalBlockRange[] {
+  const lines = text.split(/\r?\n/);
+  const ranges: LogicalBlockRange[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    if (lines[i]!.trim().length === 0) {
+      i += 1;
+      continue;
+    }
+    const runStart = i;
+    const runKind = classifyBlockKind(lines[i]!);
+    let runEnd = i;
+    while (runEnd < lines.length && lines[runEnd]!.trim().length > 0) {
+      runEnd += 1;
+    }
+    const last = ranges[ranges.length - 1];
+    if (runKind === "list" && last?.kind === "list") {
+      // Coalesce adjacent list run into the previous logical list block.
+      last.endLine = runEnd - 1;
+    } else {
+      ranges.push({
+        index: ranges.length,
+        kind: runKind,
+        startLine: runStart,
+        endLine: runEnd - 1
+      });
+    }
+    i = runEnd + 1;
   }
-  return text.split(/\n{2,}/).map((block) => block.replace(/\s+$/, ""));
+  return ranges;
 }
 
 function applyTailTrim(text: string, draftSkeleton: StructuralSkeleton, dropFrom: number): string {
-  const rawBlocks = rawBlocksOf(text);
-  const nonEmptyIndices: number[] = [];
-  for (let i = 0; i < rawBlocks.length; i += 1) {
-    if (rawBlocks[i]!.trim().length > 0) {
-      nonEmptyIndices.push(i);
-    }
-  }
-  if (dropFrom >= nonEmptyIndices.length) {
+  void draftSkeleton;
+  const ranges = findLogicalBlockRanges(text);
+  if (dropFrom >= ranges.length) {
     return text;
   }
-  void draftSkeleton;
-  const cutAt = nonEmptyIndices[dropFrom]!;
-  return rawBlocks.slice(0, cutAt).join(RAW_BLOCK_SEPARATOR).replace(/\s+$/u, "");
+  const cutAtLine = ranges[dropFrom]!.startLine;
+  const lines = text.split(/\r?\n/);
+  return lines.slice(0, cutAtLine).join("\n").replace(/\s+$/u, "");
 }
 
 function applyListItemTrim(text: string, blockIndex: number, keepItems: number): string {
-  const rawBlocks = rawBlocksOf(text);
-  let nonEmptyCounter = -1;
-  for (let i = 0; i < rawBlocks.length; i += 1) {
-    if (rawBlocks[i]!.trim().length === 0) {
-      continue;
-    }
-    nonEmptyCounter += 1;
-    if (nonEmptyCounter !== blockIndex) {
-      continue;
-    }
-    const lines = rawBlocks[i]!.split(/\r?\n/);
-    const keptLines: string[] = [];
-    let kept = 0;
-    let stopAfter = false;
-    for (const line of lines) {
-      if (LIST_ITEM_LINE_PATTERN.test(line)) {
-        if (stopAfter) {
-          continue;
-        }
-        if (kept < keepItems) {
-          keptLines.push(line);
-          kept += 1;
-          if (kept >= keepItems) {
-            stopAfter = true;
-          }
-          continue;
-        }
-        // Excess list item: skip.
-        continue;
-      }
-      if (stopAfter) {
-        // After the kept items end, drop trailing list-only filler (blank
-        // lines between bullets get collapsed).
-        if (line.trim().length === 0) {
-          continue;
-        }
-        // Anything non-bullet after the kept items breaks the trim window —
-        // we don't want to swallow legitimate prose. Stop trimming here.
-        stopAfter = false;
-        keptLines.push(line);
-        continue;
-      }
-      keptLines.push(line);
-    }
-    rawBlocks[i] = keptLines.join("\n").replace(/\s+$/u, "");
-    break;
+  const ranges = findLogicalBlockRanges(text);
+  if (blockIndex >= ranges.length || ranges[blockIndex]!.kind !== "list") {
+    return text;
   }
-  return rawBlocks.join(RAW_BLOCK_SEPARATOR).replace(/\s+$/u, "");
+  const target = ranges[blockIndex]!;
+  const lines = text.split(/\r?\n/);
+  const out: string[] = [];
+  for (let j = 0; j < target.startLine; j += 1) {
+    out.push(lines[j]!);
+  }
+  let kept = 0;
+  let trailingBlankSkipped = false;
+  for (let j = target.startLine; j <= target.endLine; j += 1) {
+    const line = lines[j]!;
+    if (LIST_ITEM_LINE_PATTERN.test(line)) {
+      if (kept < keepItems) {
+        out.push(line);
+        kept += 1;
+        trailingBlankSkipped = false;
+      }
+      // else: drop excess bullet
+      continue;
+    }
+    if (line.trim().length === 0) {
+      if (kept < keepItems) {
+        out.push(line);
+      } else if (!trailingBlankSkipped) {
+        // After we've kept the last bullet we want, drop any trailing blank
+        // lines that were sitting between bullets (avoids orphan blanks).
+        trailingBlankSkipped = true;
+      }
+      continue;
+    }
+    // Non-bullet, non-blank line inside what parseStructure called a list
+    // block: typically a continuation line indented under a bullet. Keep
+    // it iff we haven't yet hit the keep limit OR it directly follows a
+    // kept bullet.
+    if (kept <= keepItems) {
+      out.push(line);
+    }
+  }
+  for (let j = target.endLine + 1; j < lines.length; j += 1) {
+    out.push(lines[j]!);
+  }
+  return out.join("\n").replace(/\s+$/u, "");
 }
 
 /**

--- a/test/structure-skeleton.test.ts
+++ b/test/structure-skeleton.test.ts
@@ -226,3 +226,81 @@ test("alignDraftToSourceSkeleton trims when no placeholders are touched", () => 
   const placeholderCount = (aligned.match(/@@MDZH_LINK_DESTINATION_0001@@/g) ?? []).length;
   assert.equal(placeholderCount, 1);
 });
+
+test("parseStructure coalesces blank-separated bullets into a single list block", () => {
+  // Spec-driven / Medium-flavor pattern: bullets with blank lines between
+  // each item. Without coalescing, the skeleton sees N list(1) blocks and
+  // aligner misidentifies "list overflow" as "tail block extra paragraph".
+  const text = [
+    "Lead-in.",
+    "",
+    "- a",
+    "",
+    "- b",
+    "",
+    "- c",
+    "",
+    "Closing line.",
+    ""
+  ].join("\n");
+  const skel = parseStructure(text);
+  assert.equal(skel.length, 3, `expected 3 logical blocks, got ${skel.length}`);
+  assert.equal(skel[0]!.kind, "paragraph");
+  assert.equal(skel[1]!.kind, "list");
+  assert.equal(skel[1]!.listItemCount, 3);
+  assert.equal(skel[2]!.kind, "paragraph");
+});
+
+test("alignDraftToSourceSkeleton handles middle list overflow + tail prose dup (chunk 13 pattern)", () => {
+  // Mirror spec-driven §The Tools With Specs subsection (L378-390 of fixture).
+  // Draft adds 1 extra middle bullet AND duplicates the italic caption at
+  // the tail — exact spec8 chunk-13 failure pattern. Aligner must trim to
+  // bullet count = 4 AND drop the duplicate tail caption.
+  const source = [
+    "This way:",
+    "",
+    "- Specs are version-controlled",
+    "",
+    "- Linked to code that implements them",
+    "",
+    "- Every PR references a spec",
+    "",
+    "- Nothing gets lost",
+    "",
+    "![](@@MDZH_IMAGE_DESTINATION_0007@@)",
+    "",
+    "*How we can use the templates and it is easy to use*",
+    ""
+  ].join("\n");
+  const draft = [
+    "这样：",
+    "",
+    "- 规格被版本化",
+    "",
+    "- 链接到实现它的代码",
+    "",
+    "- 每个 PR 都引用一份规格",
+    "",
+    "- 不会丢失任何内容",
+    "",
+    "- 不会丢失任何内容",
+    "",
+    "![](@@MDZH_IMAGE_DESTINATION_0007@@)",
+    "",
+    "*如何使用模板，简单易用*",
+    "",
+    "*如何使用模板，简单易用*",
+    ""
+  ].join("\n");
+
+  const aligned = alignDraftToSourceSkeleton(source, draft);
+  const skel = parseStructure(aligned);
+
+  assert.equal(skel.length, 4, `expected 4 logical blocks, got ${skel.length}`);
+  assert.equal(skel[1]!.kind, "list");
+  assert.equal(skel[1]!.listItemCount, 4);
+  const italicLines = aligned.split("\n").filter((line) => line.startsWith("*如何"));
+  assert.equal(italicLines.length, 1);
+  const placeholderCount = (aligned.match(/@@MDZH_IMAGE_DESTINATION_0007@@/g) ?? []).length;
+  assert.equal(placeholderCount, 1);
+});


### PR DESCRIPTION
## Summary

PR #101 上线后 spec8 chunk 13 仍 fatal 的 root cause：**Medium-flavor 导出**用空行分隔每条 bullet，原 parseStructure 把每条当独立 list(1) 块。aligner 在「draft 多 1 条 bullet + 多 1 条 tail prose dup」场景下砍错了——tail trim 砍掉 dup italic 但保留了多余 bullet。

修法：parseStructure 把连续 list 块合并成单个逻辑 list 块（listItemCount 累加）。apply* 同步用 `findLogicalBlockRanges` 按合并后的边界扫描。

## Verification

- 300 单元 + typecheck + build 全绿
- 新增 2 项端到端：parseStructure 合并行为；chunk 13 实测形态完整恢复

## Notes

- chunk 7 的「embedded template 中多 fileName 行」是不同性质（伪代码内部污染），不在本 PR 范围
- 现有 13 项 skeleton 单元继续绿，行为一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)