### PR TITLE
fix: literal-line dedup 收编 chunk 7 类型签名内字面行复制

### DIFF
--- a/src/structure-skeleton.ts
+++ b/src/structure-skeleton.ts
@@ -172,6 +172,87 @@ export function planTailTrim(
 }
 
 /**
+ * Find non-blank lines in draft whose exact-text occurrence count exceeds
+ * the same line's occurrence count in source. These are model-introduced
+ * literal duplicates — typically inside code-style or pseudo-code template
+ * blocks where the model accidentally re-emits a line like `fileName: string`
+ * that was supposed to appear once. Returns the line indices to drop.
+ *
+ * Rules:
+ * - Only considers lines that ALSO appear in source (count >= 1). Lines that
+ *   never appear in source are likely translation-side text and are skipped
+ *   to avoid misclassifying paraphrased duplicates as literal duplicates.
+ * - Drops the LATER occurrences (keeps the first N where N = source count),
+ *   so the original first-occurrence position stays anchored.
+ *
+ * Returns null when nothing needs trimming.
+ */
+export function planLiteralLineDedup(
+  source: string,
+  draft: string
+): { removeAtIndices: readonly number[] } | null {
+  const sourceLines = source.split(/\r?\n/);
+  const draftLines = draft.split(/\r?\n/);
+
+  const sourceCounts = new Map<string, number>();
+  for (const line of sourceLines) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+    sourceCounts.set(trimmed, (sourceCounts.get(trimmed) ?? 0) + 1);
+  }
+
+  const draftSeenCounts = new Map<string, number>();
+  const removeAtIndices: number[] = [];
+  for (let i = 0; i < draftLines.length; i += 1) {
+    const trimmed = draftLines[i]!.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+    const sourceCount = sourceCounts.get(trimmed) ?? 0;
+    if (sourceCount === 0) {
+      continue;
+    }
+    const seen = (draftSeenCounts.get(trimmed) ?? 0) + 1;
+    draftSeenCounts.set(trimmed, seen);
+    if (seen > sourceCount) {
+      removeAtIndices.push(i);
+    }
+  }
+
+  if (removeAtIndices.length === 0) {
+    return null;
+  }
+  return { removeAtIndices };
+}
+
+function applyLiteralLineDedup(text: string, removeAtIndices: readonly number[]): string {
+  if (removeAtIndices.length === 0) {
+    return text;
+  }
+  const drop = new Set(removeAtIndices);
+  const lines = text.split(/\r?\n/);
+  const out: string[] = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    if (drop.has(i)) {
+      continue;
+    }
+    out.push(lines[i]!);
+  }
+  // Collapse double-blank-lines that the dedup might have introduced when
+  // an isolated literal line (with blank lines on both sides) was dropped.
+  const compacted: string[] = [];
+  for (const line of out) {
+    if (line.trim().length === 0 && compacted[compacted.length - 1]?.trim().length === 0) {
+      continue;
+    }
+    compacted.push(line);
+  }
+  return compacted.join("\n").replace(/\s+$/u, "");
+}
+
+/**
  * Detect the case where source and draft have the same block count but a
  * specific list block in draft has MORE items than the source counterpart,
  * and the extra items appear to be a duplicate run of earlier items. Returns
@@ -353,6 +434,19 @@ export function alignDraftToSourceSkeleton(source: string, draft: string): strin
   const overflowPlan = planListOverflowTrim(sourceSkeleton, draftSkeleton);
   if (overflowPlan) {
     const candidate = applyListItemTrim(body, overflowPlan.blockIndex, overflowPlan.keepItems);
+    if (countProtectedPlaceholders(candidate) === draftPlaceholderCount) {
+      body = candidate;
+    }
+  }
+
+  // Final pass: literal-line dedup. Catches model duplicating an exact line
+  // that lives outside the list / tail-block patterns (e.g., a single
+  // `fileName: string` line inside an embedded type-signature template that
+  // the model accidentally re-emits). Skipped when the source body itself
+  // is empty.
+  const literalPlan = planLiteralLineDedup(source, body);
+  if (literalPlan) {
+    const candidate = applyLiteralLineDedup(body, literalPlan.removeAtIndices);
     if (countProtectedPlaceholders(candidate) === draftPlaceholderCount) {
       body = candidate;
     }

--- a/test/structure-skeleton.test.ts
+++ b/test/structure-skeleton.test.ts
@@ -5,6 +5,7 @@ import {
   alignDraftToSourceSkeleton,
   parseStructure,
   planListOverflowTrim,
+  planLiteralLineDedup,
   planTailTrim,
   type StructuralSkeleton
 } from "../src/structure-skeleton.js";
@@ -249,6 +250,85 @@ test("parseStructure coalesces blank-separated bullets into a single list block"
   assert.equal(skel[1]!.kind, "list");
   assert.equal(skel[1]!.listItemCount, 3);
   assert.equal(skel[2]!.kind, "paragraph");
+});
+
+test("planLiteralLineDedup flags literal-line duplicates inside an embedded type-signature template (chunk 7 pattern)", () => {
+  // Source has User { ... } and Photo { ... } blocks where `fileName: string`
+  // appears exactly once (only inside Photo). The model accidentally re-emits
+  // that line a second time inside the User block.
+  const source = [
+    "type User = {",
+    "  id: string;",
+    "  name: string;",
+    "};",
+    "",
+    "type Photo = {",
+    "  id: string;",
+    "  fileName: string;",
+    "};",
+    ""
+  ].join("\n");
+  const draft = [
+    "type User = {",
+    "  id: string;",
+    "  name: string;",
+    "  fileName: string;",
+    "};",
+    "",
+    "type Photo = {",
+    "  id: string;",
+    "  fileName: string;",
+    "};",
+    ""
+  ].join("\n");
+
+  const plan = planLiteralLineDedup(source, draft);
+  assert.ok(plan, "expected a literal-line dedup plan");
+  assert.equal(plan!.removeAtIndices.length, 1);
+
+  const aligned = alignDraftToSourceSkeleton(source, draft);
+  const occurrences = aligned.split("\n").filter((line) => line.trim() === "fileName: string;").length;
+  assert.equal(occurrences, 1, `expected exactly 1 \`fileName: string;\` line, got ${occurrences}`);
+});
+
+test("planLiteralLineDedup leaves translation-side text alone even if it repeats", () => {
+  // Source is English; draft is Chinese with a duplicated Chinese line. None of
+  // the duplicated draft lines appear in source verbatim, so literal dedup
+  // must NOT touch them — that's the n-gram dedup's job, not literal dedup's.
+  const source = "Lead-in.\n\nThis is a long sentence that explains something.\n";
+  const draft = [
+    "导语。",
+    "",
+    "这是一句解释什么的长句。",
+    "这是一句解释什么的长句。",
+    ""
+  ].join("\n");
+
+  const plan = planLiteralLineDedup(source, draft);
+  assert.equal(plan, null, "literal dedup should not flag draft-only text");
+});
+
+test("alignDraftToSourceSkeleton's literal-line dedup respects placeholder guard", () => {
+  // Source has a single line with a placeholder; draft duplicates that exact
+  // line. Removing the duplicate would drop one placeholder occurrence, so
+  // the placeholder guard must roll the trim back.
+  const source = [
+    "Lead-in.",
+    "",
+    "See [doc](@@MDZH_LINK_DESTINATION_0001@@).",
+    ""
+  ].join("\n");
+  const draft = [
+    "Lead-in.",
+    "",
+    "See [doc](@@MDZH_LINK_DESTINATION_0001@@).",
+    "See [doc](@@MDZH_LINK_DESTINATION_0001@@).",
+    ""
+  ].join("\n");
+
+  const aligned = alignDraftToSourceSkeleton(source, draft);
+  const placeholderCount = (aligned.match(/@@MDZH_LINK_DESTINATION_0001@@/g) ?? []).length;
+  assert.equal(placeholderCount, 2, "guard must keep all placeholders intact");
 });
 
 test("alignDraftToSourceSkeleton handles middle list overflow + tail prose dup (chunk 13 pattern)", () => {


### PR DESCRIPTION
## 背景
spec-driven 长文 chunk 7 是一个嵌入了 TypeScript 类型签名的伪代码模板。模型在翻译时会把 \`Photo { fileName: string; }\` 里的 \`fileName: string;\` 错误地多写一份到前面的 \`User { ... }\` 块里，结构骨架对齐器（PR #100/#101/#102）抓不到——因为 source / draft 的逻辑块数和列表项数都对得上，只是 paragraph 内部多了一行字面重复。

## 改动
新增 \`planLiteralLineDedup\` + \`applyLiteralLineDedup\`：
- 比对 source / draft 的非空行频率
- 仅命中同时出现在 source 中的行（避免误删译文侧的近似重复）
- 保留前 N 个原始位置（N = source count），多出来的 LATER 位置裁掉
- 串到 \`alignDraftToSourceSkeleton\` 末尾，与现有 tail / overflow trim 一样走 placeholder 守恒守卫

## 验证
- \`npm run verify\` 全绿，303 → 已加 3 个新单测：
  - chunk 7 模板内字面复制（核心场景）
  - 译文侧重复不动（n-gram dedup 的领地）
  - placeholder 守恒守卫回滚

## 关联
- 上游：resilience plan §3.2，PR #100 / #101 / #102 一脉
- 后续：合并后跑 spec10 long smoke，确认 chunk 7 是否清掉

🤖 Generated with [Claude Code](https://claude.com/claude-code)