### PR TITLE
fix: json-blocks 结构膨胀类违规不再退回 freeform draft

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -6660,7 +6660,32 @@ async function translateProtectedSegment(
       lastDraftViolation = jsonBlockError instanceof Error ? jsonBlockError.message : String(jsonBlockError);
     }
   }
-  if (!draftResult || lastDraftViolation) {
+  // Freeform fallback policy (chunk 7 root cause):
+  // After json-blocks strict retry, two violation classes need different
+  // handling. "Content-empty" violations (empty slots, structured-output
+  // debris, source-verbatim echoes, dropped list items) leave the segment
+  // with nothing to translate, and the freeform text rescue is a
+  // legitimate last-ditch path. "Structural-expansion" violations
+  // (expanded block structure, expanded length, introduced
+  // headings/code) mean the model produced too MUCH — letting freeform
+  // rewrite the whole segment without slot constraints reliably makes it
+  // worse: with embedded pseudo-template chunks (spec-driven §How To
+  // Implement) freeform reorders sections and drops headings, surfacing
+  // upstream as paragraph_match / first_mention_bilingual /
+  // embedded_template_integrity failures that hard-fail the chunk. Block
+  // freeform on the structural-expansion class so the chunk-level
+  // rescue / soft-gate path can preserve shape instead.
+  const wasJsonBlocksMode = structuralSegmentDraft?.mode === "json-blocks";
+  const lastViolationIsStructuralExpansion =
+    lastDraftViolation !== null &&
+    (lastDraftViolation.includes("expanded the block structure") ||
+      lastDraftViolation.includes("expanded far beyond") ||
+      lastDraftViolation.includes("introduced heading blocks") ||
+      lastDraftViolation.includes("introduced code blocks"));
+  const shouldFallThroughToFreeform =
+    !draftResult ||
+    (lastDraftViolation !== null && !(wasJsonBlocksMode && lastViolationIsStructuralExpansion));
+  if (shouldFallThroughToFreeform) {
     for (const [attemptIndex, draftPrompt] of draftPrompts.entries()) {
       const rawDraftResult = await executeDraft(draftPrompt, false);
       draftResult = {

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -3186,6 +3186,123 @@ test("translateMarkdownArticle retries a failed JSON block draft with a stricter
   assert.match(result.markdown, /--dangerously-skip-permissions/);
 });
 
+test("JSON-blocks strict retry violations no longer fall back to the freeform draft lane (chunk 7 root cause)", async () => {
+  // chunk 7 of the spec-driven long-form article fails because:
+  //   1. The embedded spec template (User { ... } / Photo { ... } / **## 5.
+  //      API Contracts** / **## 6. Error Handling** / ...) is split into
+  //      ~30 source blocks by splitPromptBlocks.
+  //   2. The model returns json-blocks slots whose contents themselves
+  //      contain blank lines, so reconstructJsonBlockDraft produces text
+  //      that splitPromptBlocks re-splits into more blocks than the
+  //      source — `getDraftContractViolation` flags it as
+  //      "draft expanded the block structure beyond the source segment".
+  //   3. The strict JSON-block retry hits the same violation.
+  //   4. `translateProtectedSegment` then falls back to the FREEFORM text
+  //      rescue lane, where the model is free to paraphrase the entire
+  //      segment. With a complex embedded template, the model rewrites
+  //      the section in a different order and silently drops a heading.
+  //
+  // This test reproduces the structural condition: simple 4-block source,
+  // mock returns slots with embedded blank lines on both json-blocks
+  // attempts. We expect the bug to surface as `freeformDraftCalls > 0`
+  // (current behaviour). After the fix, freeform must NOT be invoked when
+  // the json-blocks lane has already been chosen — the failure should be
+  // surfaced upstream (HardGateError or chunk-level source fallback).
+  const source = [
+    "First paragraph.",
+    "",
+    "Second paragraph.",
+    "",
+    "Third paragraph.",
+    "",
+    "Fourth paragraph.",
+    ""
+  ].join("\n");
+
+  // Each slot embeds blank lines so reconstruction yields ≥ 4+3 blocks
+  // and triggers `translatedBlocks.length > sourceBlocks.length + 2`.
+  const inflatedSlot = (idx: number) =>
+    [
+      `第 ${idx} 段译文。`,
+      "",
+      `第 ${idx} 段附注 1。`,
+      "",
+      `第 ${idx} 段附注 2。`,
+      "",
+      `第 ${idx} 段附注 3。`
+    ].join("\n");
+
+  let jsonDraftCalls = 0;
+  let freeformDraftCalls = 0;
+
+  const executor: CodexExecutor = {
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(createEmptyAnchorCatalog());
+      }
+      if (options.outputSchema && prompt.includes("### BLOCK 1")) {
+        jsonDraftCalls += 1;
+        return createExecResult(
+          JSON.stringify({
+            blocks: [inflatedSlot(1), inflatedSlot(2), inflatedSlot(3), inflatedSlot(4)]
+          })
+        );
+      }
+      if (options.outputSchema || prompt.includes('"hard_checks"') || prompt.includes("只返回 JSON")) {
+        return createExecResult(wrapAuditForSegments(prompt, createAudit(true)));
+      }
+      if (prompt.includes("【英文原文】")) {
+        freeformDraftCalls += 1;
+        return createExecResult("FREEFORM_FALLBACK_TRIGGERED");
+      }
+      return createExecResult(extractPromptSection(prompt, "【当前译文】") ?? "中文占位译文");
+    }
+  };
+
+  let translationError: unknown = null;
+  let translatedMarkdown: string | null = null;
+  try {
+    const result = await translateMarkdownArticle(source, {
+      executor,
+      formatter: async (markdown) => markdown,
+      softGate: true
+    });
+    translatedMarkdown = result.markdown;
+  } catch (error) {
+    translationError = error;
+  }
+
+  // At minimum, the initial + strict json-blocks attempt must run on the
+  // primary model. If chunk-level rescue (default gpt-5.5) kicks in, the
+  // same mock will replay the json-blocks attempts for the rescue model,
+  // so the count can be 2 (no rescue) or 4 (with rescue) — both prove
+  // that the freeform fallback path was bypassed.
+  assert.ok(
+    jsonDraftCalls >= 2,
+    `expected at least 2 json-blocks attempts, got ${jsonDraftCalls}`
+  );
+
+  // Core fix: json-blocks structural-expansion contract violations must
+  // NOT route into the freeform text rescue. The freeform model would
+  // otherwise get free rein to rewrite the whole segment without slot
+  // constraints — exactly the path that historically caused chunk 7's
+  // section reordering / dropped-heading regression.
+  assert.equal(
+    freeformDraftCalls,
+    0,
+    `freeform draft must not fire after a json-blocks structural-expansion violation, got ${freeformDraftCalls} calls`
+  );
+
+  // The freeform marker should never appear anywhere — neither in the
+  // produced markdown nor in the failure surface.
+  const surface = translatedMarkdown ?? (translationError instanceof Error ? translationError.message : "");
+  assert.doesNotMatch(
+    surface,
+    /FREEFORM_FALLBACK_TRIGGERED/,
+    "freeform marker must not leak into output or error after json-blocks fails strict retry"
+  );
+});
+
 test("translateMarkdownArticle fails fast when analysis quality collapses below the heading-plan threshold", async () => {
   const source = [
     "# Title",


### PR DESCRIPTION
## 背景

spec-driven 长文 chunk 7 hard-fail 中止整 run（exit code 4），调查后发现是流程层的弹性问题，不是新合的 PR 引入：

1. chunk 7 的 source 含嵌入式规格模板（**# Specification** / **## 1. Overview** … **## 7. Acceptance Criteria**），splitPromptBlocks 切成 ~30 个块。
2. json-blocks lane 模型在 slot 内塞了带空行的多段文本 → reconstructJsonBlockDraft 后 splitPromptBlocks 再切出更多块 → \`getDraftContractViolation\` 触发 \"draft expanded the block structure beyond the source segment\"。
3. strict json-blocks retry 同样违规。
4. **流程兜底到 freeform text rescue**——模型在没有槽位约束下重写整 segment，重排章节顺序、漏掉 \`**## 6. Error Handling**\` 整段。
5. audit 报 paragraph_match / first_mention_bilingual / embedded_template_integrity 三个结构性 hard-check 失败 → soft-gate 不接管 → 整 run 中止。

## 改动

\`translateProtectedSegment\` 把 contract violation 分两类区别处理：

- **content-empty 类**（empty / structured-output debris / source verbatim / dropped list item / meta text）继续允许 freeform 兜底——模型没产出实质内容，给一个不同形态的 prompt 再试有意义。
- **structural-expansion 类**（\`expanded the block structure\` / \`expanded far beyond\` / \`introduced heading blocks\` / \`introduced code blocks\`）**阻断 freeform**——模型已经产出但搞坏了结构，让它再自由发挥只会更乱。违规向上抛 → chunk-level rescue（gpt-5.5）/ soft-gate fallback to source。

## 验证

**单测**：新增最小复现测试 \`JSON-blocks strict retry violations no longer fall back to the freeform draft lane (chunk 7 root cause)\`：
- 4 块 paragraph source，mock 让 json-blocks 每个 slot 内嵌空行触发 expanded
- 断言 \`freeformDraftCalls === 0\`、\`jsonDraftCalls >= 2\`、freeform marker 不出现在产出/错误里

\`npm run verify\` 304 全绿（含 1 个新测试 + 之前破坏的 \"empty content fallback to text rescue\" 已恢复）。

**长文 smoke**（spec-driven §How To Implement）：

| | 修复前 | 修复后 |
|---|---|---|
| chunk 7 | hard-fail，2 cycles + rescue 都失败，中止整 run | ✅ 0 repair cycle，29s 一遍过 |
| run | exit code 4，chunks 12-17 没跑到 | exit code 0，17/17 chunks 全部跑完，output.md 14.5KB |

中间 4 个 soft-gate 的 chunk（3/11/13/15）与本次修复无关——3/13/15 是 codex CLI 网络超时，11 是 placeholder 复制独立问题。

## 关联

- 上游：resilience plan §3.2 / §3.3，PR #100/#101/#102/#103 一脉
- 后续：保留 chunk 11 placeholder 复制 / codex 超时作为独立观察项

🤖 Generated with [Claude Code](https://claude.com/claude-code)