### PR TITLE
fix: anchor 注入识别双语首现 + repair 默认升 gpt-5.5

### DIFF
--- a/src/anchor-normalization.ts
+++ b/src/anchor-normalization.ts
@@ -1630,7 +1630,17 @@ function lineAlreadyHasFamilyVariantAnchorParen(text: string, english: string): 
   if (!target) {
     return null;
   }
-  for (const match of text.matchAll(/（([A-Za-z][A-Za-z0-9 .+/_\-]*)）/gu)) {
+  // Match either a pure-English paren `（Sandbox mode）` or the bilingual
+  // first-mention canonical with a Chinese-comma + abbreviation suffix
+  // `（Spouse Activation Factor，SAF）`. Capturing only the leading English
+  // phrase keeps the family-match logic below unchanged; the optional
+  // abbreviation tail is consumed by the regex but discarded. Without this
+  // tolerance, the injector misclassified bilingual canonicals already
+  // present in the line and stacked a second paren on top (loonshots
+  // chunk 23 spouse-activation-factor regression).
+  for (const match of text.matchAll(
+    /（([A-Za-z][A-Za-z0-9 .+/_\-]*)(?:[，][A-Za-z0-9 .+/_\-]+)?）/gu
+  )) {
     const raw = String(match[1]).trim();
     if (!raw) {
       continue;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -93,6 +93,13 @@ Performance knobs:
     original error is reported. Defaults to \`gpt-5.5\`; set to an empty
     string or \`off\` / \`none\` / \`false\` / \`0\` to disable rescue entirely.
     Trades cost & wall time for stability on flaky chunks.
+  - MDZH_REPAIR_MODEL=<model-id> overrides the model used for the per-chunk
+    repair stage (the stage that re-runs failing segments with audit's
+    must_fix list as an explicit instruction). Defaults to \`gpt-5.5\`
+    because the stronger model lands structural fixes the mini default
+    cannot. Set to \`off\` / \`none\` / \`false\` / \`0\` (or empty) to fall
+    back to the post-draft (typically mini) model. Trades cost for first-pass
+    repair success on long-form content.
 
 Exit codes:
   0  Success (may include soft-gate degraded output; see stderr for warnings).

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -99,6 +99,31 @@ const DEFAULT_MODEL = "gpt-5.4-mini";
 const MAX_REPAIR_CYCLES = 2;
 
 const DEFAULT_RESCUE_MODEL = "gpt-5.5";
+const DEFAULT_REPAIR_MODEL = "gpt-5.5";
+
+/**
+ * Repair-stage model resolution. Repair runs with audit's `must_fix` list as
+ * an explicit instruction, so a stronger model should give it the best shot
+ * at hitting the structural fixes the mini default cannot land. Default is
+ * `gpt-5.5`; users can opt back into the post-draft (typically mini) model
+ * via `MDZH_REPAIR_MODEL=off` (or `none` / `false` / `0` / empty string).
+ * Any other non-empty value is taken as the model id verbatim.
+ */
+function readRepairModel(postDraftModel: string): string {
+  const raw = process.env.MDZH_REPAIR_MODEL;
+  if (raw === undefined) {
+    return DEFAULT_REPAIR_MODEL;
+  }
+  const trimmed = raw.trim();
+  if (trimmed === "") {
+    return postDraftModel;
+  }
+  const lower = trimmed.toLowerCase();
+  if (lower === "off" || lower === "none" || lower === "false" || lower === "0") {
+    return postDraftModel;
+  }
+  return trimmed;
+}
 
 function readRescueModel(): string | null {
   // Stronger fallback model used when a chunk exhausts its normal
@@ -2731,6 +2756,7 @@ export async function translateMarkdownArticle(source: string, options: Translat
   const formatter = options.formatter ?? formatTranslatedBody;
   const draftModel = options.model ?? (process.env.TRANSLATION_MODEL?.trim() || DEFAULT_MODEL);
   const postDraftModel = options.postDraftModel ?? (process.env.POST_DRAFT_MODEL?.trim() || draftModel);
+  const repairModel = readRepairModel(postDraftModel);
   const styleMode = resolveStyleMode(options.styleMode);
   const postDraftReasoningEffort = process.env.POST_DRAFT_REASONING_EFFORT?.trim()
     ? (process.env.POST_DRAFT_REASONING_EFFORT.trim() as ReasoningEffort)
@@ -2928,6 +2954,7 @@ export async function translateMarkdownArticle(source: string, options: Translat
           executor,
           draftModel,
           postDraftModel,
+          repairModel,
           options,
           sourcePathHint,
           spanIndex,
@@ -2973,6 +3000,7 @@ export async function translateMarkdownArticle(source: string, options: Translat
               executor,
               draftModel: rescueModel,
               postDraftModel: rescueModel,
+              repairModel: rescueModel,
               options,
               sourcePathHint,
               spanIndex,
@@ -3290,6 +3318,8 @@ type ChunkTranslationContext = {
   executor: CodexExecutor;
   draftModel: string;
   postDraftModel: string;
+  /** Model used for repair stage (default `gpt-5.5`, see readRepairModel). */
+  repairModel: string;
   cwd: string;
   sourcePathHint: string;
   options: TranslateOptions;
@@ -7394,7 +7424,7 @@ async function repairDraftedSegment(
         prompt,
         {
           cwd: context.cwd,
-          model: context.postDraftModel,
+          model: context.repairModel,
           reasoningEffort: context.postDraftReasoningEffort ?? REPAIR_REASONING_EFFORT,
           reuseSession: false,
           onStderr: (stderrChunk) =>
@@ -7429,7 +7459,7 @@ async function repairDraftedSegment(
         prompt,
         {
           cwd: context.cwd,
-          model: context.postDraftModel,
+          model: context.repairModel,
           reasoningEffort: context.postDraftReasoningEffort ?? REPAIR_REASONING_EFFORT,
           reuseSession: false,
           outputSchema: buildJsonBlockDraftSchema(blockCount),

--- a/test/anchor-normalization.test.ts
+++ b/test/anchor-normalization.test.ts
@@ -517,6 +517,26 @@ test("injectPlannedAnchorText injects a missing anchor into a paragraph line", (
   assert.equal(normalized, "提示注入攻击（Prompt injection attacks）会隐藏恶意指令。");
 });
 
+test("injectPlannedAnchorText does not re-inject when the line already carries `（English，ABBR）` bilingual canonical (loonshots chunk 23 root cause)", () => {
+  // Root cause: lineAlreadyHasFamilyVariantAnchorParen's regex only accepts
+  // pure-ASCII parenthetical content, so legitimate first-mention forms with
+  // a Chinese-comma + abbreviation suffix — `（Spouse Activation Factor，
+  // SAF）` — are not recognized as "already injected" and the injector
+  // appends a second `（Spouse Activation Factor）`, producing the runaway
+  // chain that audit later flags as polluted first-mention bilingual.
+  const slice = createSlice({
+    requiredAnchors: [createAnchor("anchor-1", "Spouse Activation Factor", "配偶激活因子")]
+  });
+  const source = "He coined the term Spouse Activation Factor (SAF) for this dynamic.";
+  const translated = "他把这种现象称为配偶激活因子（Spouse Activation Factor，SAF）。";
+
+  const normalized = injectPlannedAnchorText(source, translated, slice);
+
+  // Must NOT append `（Spouse Activation Factor）` after the existing canonical;
+  // the bilingual abbreviation form already established the anchor.
+  assert.equal(normalized, translated);
+});
+
 test("injectPlannedAnchorText does not expand command phrases inside Commands-style list items", () => {
   const slice = createSlice({
     requiredAnchors: [

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -4225,6 +4225,169 @@ test("MDZH_RESCUE_MODEL=off explicitly disables rescue", async () => {
   assert.equal(rescueEvents.length, 0, "no rescue events should fire when MDZH_RESCUE_MODEL=off");
 });
 
+test("default behavior: repair defaults to gpt-5.5 when MDZH_REPAIR_MODEL is unset", async () => {
+  // Trigger one repair cycle (audit fails on first pass, second audit passes)
+  // and verify the repair stage call landed on gpt-5.5, not the mini default.
+  const source = "## Hello\n\nWorld.\n";
+
+  let auditCalls = 0;
+  const repairModelsSeen: string[] = [];
+  const executor: CodexExecutor = {
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(createEmptyAnchorCatalog());
+      }
+      if (isBundledAuditPrompt(prompt, options) || (options.outputSchema && prompt.includes('"hard_checks"'))) {
+        auditCalls += 1;
+        // First audit fails to force a repair; subsequent audits pass.
+        if (auditCalls === 1) {
+          return createExecResult(
+            wrapAuditForSegments(prompt, createAudit(false, ["术语首现需补对照"]))
+          );
+        }
+        return createExecResult(wrapAuditForSegments(prompt, createAudit(true)));
+      }
+      // The repair stage runs without outputSchema and the prompt contains the
+      // current translation marker — record which model was used.
+      const currentTranslation = extractPromptSection(prompt, "【当前译文】");
+      if (currentTranslation !== null) {
+        repairModelsSeen.push(options.model ?? "<unset>");
+        return createExecResult(currentTranslation);
+      }
+      const sourceSection = extractPromptSection(prompt, "【英文原文】");
+      return createExecResult(sourceSection ?? "中文占位译文");
+    }
+  };
+
+  const previous = process.env.MDZH_REPAIR_MODEL;
+  delete process.env.MDZH_REPAIR_MODEL;
+  try {
+    await translateMarkdownArticle(source, {
+      executor,
+      formatter: async (markdown) => markdown,
+      softGate: true
+    });
+  } finally {
+    if (previous !== undefined) {
+      process.env.MDZH_REPAIR_MODEL = previous;
+    }
+  }
+
+  assert.ok(
+    repairModelsSeen.length > 0,
+    `expected at least one repair stage call, got ${repairModelsSeen.length}`
+  );
+  for (const model of repairModelsSeen) {
+    assert.equal(
+      model,
+      "gpt-5.5",
+      `repair stage should default to gpt-5.5, observed ${model}`
+    );
+  }
+});
+
+test("MDZH_REPAIR_MODEL overrides the repair stage model", async () => {
+  const source = "## Hello\n\nWorld.\n";
+
+  let auditCalls = 0;
+  const repairModelsSeen: string[] = [];
+  const executor: CodexExecutor = {
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(createEmptyAnchorCatalog());
+      }
+      if (isBundledAuditPrompt(prompt, options) || (options.outputSchema && prompt.includes('"hard_checks"'))) {
+        auditCalls += 1;
+        if (auditCalls === 1) {
+          return createExecResult(
+            wrapAuditForSegments(prompt, createAudit(false, ["术语首现需补对照"]))
+          );
+        }
+        return createExecResult(wrapAuditForSegments(prompt, createAudit(true)));
+      }
+      const currentTranslation = extractPromptSection(prompt, "【当前译文】");
+      if (currentTranslation !== null) {
+        repairModelsSeen.push(options.model ?? "<unset>");
+        return createExecResult(currentTranslation);
+      }
+      const sourceSection = extractPromptSection(prompt, "【英文原文】");
+      return createExecResult(sourceSection ?? "中文占位译文");
+    }
+  };
+
+  const previous = process.env.MDZH_REPAIR_MODEL;
+  process.env.MDZH_REPAIR_MODEL = "gpt-custom-model";
+  try {
+    await translateMarkdownArticle(source, {
+      executor,
+      formatter: async (markdown) => markdown,
+      softGate: true
+    });
+  } finally {
+    if (previous === undefined) {
+      delete process.env.MDZH_REPAIR_MODEL;
+    } else {
+      process.env.MDZH_REPAIR_MODEL = previous;
+    }
+  }
+
+  assert.ok(repairModelsSeen.length > 0);
+  for (const model of repairModelsSeen) {
+    assert.equal(model, "gpt-custom-model");
+  }
+});
+
+test("MDZH_REPAIR_MODEL=off falls back to the post-draft (mini) model", async () => {
+  const source = "## Hello\n\nWorld.\n";
+
+  let auditCalls = 0;
+  const repairModelsSeen: string[] = [];
+  const executor: CodexExecutor = {
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(createEmptyAnchorCatalog());
+      }
+      if (isBundledAuditPrompt(prompt, options) || (options.outputSchema && prompt.includes('"hard_checks"'))) {
+        auditCalls += 1;
+        if (auditCalls === 1) {
+          return createExecResult(
+            wrapAuditForSegments(prompt, createAudit(false, ["术语首现需补对照"]))
+          );
+        }
+        return createExecResult(wrapAuditForSegments(prompt, createAudit(true)));
+      }
+      const currentTranslation = extractPromptSection(prompt, "【当前译文】");
+      if (currentTranslation !== null) {
+        repairModelsSeen.push(options.model ?? "<unset>");
+        return createExecResult(currentTranslation);
+      }
+      const sourceSection = extractPromptSection(prompt, "【英文原文】");
+      return createExecResult(sourceSection ?? "中文占位译文");
+    }
+  };
+
+  const previous = process.env.MDZH_REPAIR_MODEL;
+  process.env.MDZH_REPAIR_MODEL = "off";
+  try {
+    await translateMarkdownArticle(source, {
+      executor,
+      formatter: async (markdown) => markdown,
+      softGate: true
+    });
+  } finally {
+    if (previous === undefined) {
+      delete process.env.MDZH_REPAIR_MODEL;
+    } else {
+      process.env.MDZH_REPAIR_MODEL = previous;
+    }
+  }
+
+  assert.ok(repairModelsSeen.length > 0);
+  for (const model of repairModelsSeen) {
+    assert.equal(model, "gpt-5.4-mini");
+  }
+});
+
 test("embedded_template_integrity check failure routes through repair lane and patch fix", async () => {
   // Audit reports embedded_template_integrity=false with a structured target;
   // the patch lane should fix it via literal replacement without an LLM repair


### PR DESCRIPTION
## 背景

调查 loonshots 长文翻译 chunk 21/23/27 hard-fail 整 run 的根因，发现两个独立的代码问题：

### (1) anchor 注入双层括号污染（chunk 23 报错根因之一）

\`lineAlreadyHasFamilyVariantAnchorParen\` 的反 runaway 守卫使用正则 \`/（([A-Za-z][A-Za-z0-9 .+/_\\-]*)）/gu\` —— 只匹配纯 ASCII 括号内容。

模型自己写出合法的首现锚定形式 \`配偶激活因子（Spouse Activation Factor，SAF）\` 时（含中文逗号 \`，\` + 缩写），守卫不识别为"已注入"，注入器追加第二份 canonical \`配偶激活因子（Spouse Activation Factor）\`，最终产生 \`配偶激活因子（配偶激活因子（Spouse Activation Factor），SAF）\` 这种嵌套污染。Audit 报 \`first_mention_bilingual\` 失败。

修复：放宽正则接受 \`（English[，ABBR]）\` 形式，缩写尾部被消费但不参与 family 匹配。

### (2) repair 默认升 gpt-5.5

新增 \`MDZH_REPAIR_MODEL\` 环境变量，默认 \`gpt-5.5\`。

理由：repair 阶段带着 audit 的 \`must_fix\` 指令运行，让更强模型在带反馈的情况下做结构性修复。这跟 rescue（不带反馈，整 chunk 从头来）不同——repair 升级后，模型在 cycle 1/2 内就有机会命中结构性 fix，避免一路推到 rescue 失败再 hard-fail。

\`MDZH_REPAIR_MODEL=off\` 回退到 post-draft（默认 mini）。CLI \`--help\` 同步加说明。

## 验证

- **复现 + 修复测试**：\`injectPlannedAnchorText does not re-inject when the line already carries （English，ABBR） bilingual canonical (loonshots chunk 23 root cause)\`
- **3 个新 repair-model 单测**：默认 gpt-5.5 / env 覆盖 / \`off\` 回退到 mini
- **\`npm run verify\` 308/308 全绿**

## 不修复的部分

chunk 21/27 的「段落级幻觉」（顺序错乱、漏段、跨章节挪段）跟这两个修复无关——那是模型在叙事密集长文的边界。如果 repair 升 5.5 后还是过不去，下一步走 soft-gate 真"软"（让 rescue 也失败的 chunk 一律 fallback to source）。

## 关联

- 上游：PR #104（json-blocks → freeform fallback 阻断）
- 下游：观察 loonshots 重跑 chunk 21/23/27 是否通过；不通过则做 soft-gate 真"软"

🤖 Generated with [Claude Code](https://claude.com/claude-code)