### PR TITLE
fix: soft-gate 在 rescue 失败后一律 fallback to source

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -3037,7 +3037,9 @@ export async function translateMarkdownArticle(source: string, options: Translat
 
         if (rescuedResult) {
           chunkResult = rescuedResult;
-        } else if (!options.softGate || isStructuralHardGateError(error)) {
+        } else if (!options.softGate) {
+          // Soft-gate disabled: any failure (semantic or structural) is fatal
+          // and cancels the run.
           telemetry.emit({
             ts: Date.now(),
             runId,
@@ -5623,7 +5625,7 @@ async function translateProtectedChunk(
       report(
         context.options,
         "audit",
-        `Chunk ${chunkPromptContext.chunkIndex}/${plan.chunks.length}${chunkLabel}: soft-gate cannot rescue structural hard-check failure; failing hard.`
+        `Chunk ${chunkPromptContext.chunkIndex}/${plan.chunks.length}${chunkLabel}: structural hard-check failed; deferring to chunk-level rescue / source fallback.`
       );
     }
     const failureError = new HardGateError(

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -3432,7 +3432,61 @@ test("translateMarkdownArticle under soft-gate treats first_mention_bilingual-on
   );
 });
 
-test("translateMarkdownArticle under soft-gate still throws HardGateError when a structural hard-check fails", async () => {
+test("translateMarkdownArticle under soft-gate falls back to source when a structural hard-check fails (bug 2 fix)", async () => {
+  // Pre-bug-2-fix behavior: structural hard-check failures (e.g. paragraph_match)
+  // were treated as un-rescuable under soft-gate, hard-failing the whole run.
+  // Post-fix: soft-gate must catch ANY chunk failure (semantic or structural)
+  // and fall back to the source body for that chunk so the run completes
+  // with a structurally complete output.md (failed chunks left as English).
+  const source = "# Title\n\nBody\n";
+  const structuralFailingAudit = createAudit(false, ["段落数对不上"], {
+    paragraph_match: { pass: false, problem: "source has 2 paragraphs, draft has 3" },
+    first_mention_bilingual: { pass: true, problem: "" },
+    numbers_units_logic: { pass: true, problem: "" },
+    chinese_punctuation: { pass: true, problem: "" },
+    unit_conversion_boundary: { pass: true, problem: "" },
+    protected_span_integrity: { pass: true, problem: "" },
+    embedded_template_integrity: { pass: true, problem: "" }
+  });
+
+  const sink = createMemoryTelemetrySink();
+  const result = await translateMarkdownArticle(source, {
+    executor: createP2CompatibleExecutor({
+      async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+        if (isDocumentAnalysisPrompt(prompt)) return createExecResult(createEmptyAnchorCatalog());
+        if (options.outputSchema || prompt.includes("只返回 JSON"))
+          return createExecResult(wrapAuditForSegments(prompt, structuralFailingAudit));
+        const current = extractPromptSection(prompt, "【当前译文】");
+        return createExecResult(current ?? "中文占位译文");
+      }
+    }),
+    formatter: async (markdown) => markdown,
+    softGate: true,
+    telemetry: sink
+  });
+
+  // Run must complete (no throw). Output must contain the source content for
+  // the failed chunk (English fallback).
+  assert.match(result.markdown, /Title/);
+  assert.match(result.markdown, /Body/);
+
+  // chunk.error telemetry should record `recovered: true` since soft-gate
+  // caught the structural failure rather than canceling the run.
+  const chunkErrors = [...sink.events].filter((event) => event.type === "chunk.error");
+  assert.ok(chunkErrors.length > 0, "chunk.error event should fire when soft-gate falls back");
+  for (const event of chunkErrors) {
+    assert.equal(
+      (event.meta as Record<string, unknown>).recovered,
+      true,
+      "soft-gate should record recovered=true even on structural failures"
+    );
+  }
+});
+
+test("translateMarkdownArticle without soft-gate still throws HardGateError on structural failure", async () => {
+  // Inverse of the test above: with soft-gate disabled, structural hard-check
+  // failures still propagate as HardGateError. This pins down that the bug 2
+  // fix only changes behavior under soft-gate=true.
   const source = "# Title\n\nBody\n";
   const structuralFailingAudit = createAudit(false, ["段落数对不上"], {
     paragraph_match: { pass: false, problem: "source has 2 paragraphs, draft has 3" },
@@ -3456,7 +3510,7 @@ test("translateMarkdownArticle under soft-gate still throws HardGateError when a
         }
       }),
       formatter: async (markdown) => markdown,
-      softGate: true
+      softGate: false
     }),
     (error: unknown) => {
       assert.ok(error instanceof HardGateError);


### PR DESCRIPTION
## 背景

之前 soft-gate 对「结构性 hard-check 失败」（\`paragraph_match\` / \`protected_span_integrity\`）特殊对待——即使开了 soft-gate 仍 throw \`HardGateError\` 中止整 run。

loonshots 长文跑过两轮：
- 第一轮：chunk 21/23/27 触发结构性失败 → soft-gate refuse → run 中止
- 第二轮（带 PR #105 的 anchor 修复 + repair 默认 5.5）：chunk 11 同样触发结构性失败（模型漏掉 \`Bush's answer\` 段落）→ soft-gate refuse → run 又中止

证实「段落级幻觉」是模型在叙事密集长文上的能力边界，repair 5.5 / rescue 5.5 都救不回。让 soft-gate 真"软"才能让长文跑完。

## 改动

\`src/translate.ts\` line 3040：

\`\`\`diff
- } else if (!options.softGate || isStructuralHardGateError(error)) {
+ } else if (!options.softGate) {
\`\`\`

soft-gate=true 时 rescue 失败一律 fallback to source（保留英文段，run 继续）；soft-gate=false 行为不变（结构性失败仍 throw）。

\`isStructuralHardGateError\` 的标记保留，便于将来需要区分错误类型时再用。chunk-internal 的 "soft-gate cannot rescue" log 同步改成 "deferring to chunk-level rescue / source fallback" 避免误导。

## 验证

- 反转旧测试期望：\`translateMarkdownArticle under soft-gate falls back to source when a structural hard-check fails (bug 2 fix)\` 断言 \`result.markdown\` 含原文 + \`chunk.error\` 事件 \`recovered=true\`
- 新增 inverse 测试：\`translateMarkdownArticle without soft-gate still throws HardGateError on structural failure\` 锁定非 soft-gate 路径不变
- \`npm run verify\` 309/309 全绿

## 取舍

失败 chunk 在 output.md 留英文段——读者看到这段是英文，但其他 130+ chunks 都是中文，整本书可读且结构完整。比之前"整本书翻不完"好得多。后续质量检查工具（\`smoke-quality\` 等）会清楚标出这些回退段，便于用户回头单独修。

## 关联

- 上游：PR #104（json-blocks fallback 阻断）、PR #105（anchor 双层括号 + repair 默认 5.5）
- 下游：loonshots 长文翻译可以跑完整本书，而不是被某个 chunk 拖死

🤖 Generated with [Claude Code](https://claude.com/claude-code)