### PR TITLE
fix: 清理 anchor 错绑括注（中文锚点（无关 English））

### DIFF
--- a/src/anchor-normalization.ts
+++ b/src/anchor-normalization.ts
@@ -461,6 +461,100 @@ function resolveEmphasisPlanTargetText(
   return targetText;
 }
 
+/**
+ * Strip `（English[，ABBR]）` parentheticals that follow a Chinese phrase when
+ * the parenthesised English is neither (a) present in the corresponding
+ * source line, nor (b) the canonical english of any anchor required for that
+ * line. Catches the loonshots-style misbinding where the model writes
+ * `泛美航空公司（Trans World Airlines）`: Pan Am is the source-line term but
+ * Trans World Airlines is a different entity that only appears later in the
+ * chunk. The misbound paren survives audit (Pan Am is already established
+ * earlier in the doc, so first_mention_bilingual doesn't fire) and the
+ * existing collapsers only remove duplicate / runaway chains, not pairings.
+ *
+ * Conservative: only fires when (1) the line carries at least one required
+ * anchor (so we have a sense of what is "expected" here) AND (2) the
+ * parenthesised English is absent from the source line. If the source line
+ * itself contains the same English token (case-insensitive), the binding is
+ * preserved on the assumption the model is mirroring source structure.
+ */
+export function cleanMisboundAnchorParens(
+  source: string,
+  text: string,
+  slice: PromptSlice | null
+): string {
+  if (!slice) {
+    return text;
+  }
+  const requiredAnchors = dedupePromptAnchors(slice.requiredAnchors);
+  if (requiredAnchors.length === 0) {
+    return text;
+  }
+  const sourceLines = source.split(/\r?\n/);
+  const translatedLines = text.split(/\r?\n/);
+  let changed = false;
+  // Match `中文短语（English[，ABBR]）`. The Chinese run must end immediately
+  // before `（`; the parenthesised content is the same shape accepted by
+  // lineAlreadyHasFamilyVariantAnchorParen so legitimate first-mention
+  // canonicals (含中文逗号 + 缩写) are recognised.
+  const misboundPattern =
+    /([一-鿿]+)（([A-Za-z][A-Za-z0-9 .+/_\-]*)(?:[，][A-Za-z0-9 .+/_\-]+)?）/gu;
+  for (let index = 0; index < Math.min(sourceLines.length, translatedLines.length); index += 1) {
+    const sourceLine = sourceLines[index] ?? "";
+    const translatedLine = translatedLines[index] ?? "";
+    const lineAnchors = requiredAnchors.filter((anchor) =>
+      containsSourceAnchorPhrase(sourceLine, anchor.english)
+    );
+    if (lineAnchors.length === 0) {
+      continue;
+    }
+    const sourceLower = sourceLine.toLowerCase();
+    let lineChanged = false;
+    const cleaned = translatedLine.replace(misboundPattern, (match, prefix, englishToken) => {
+      const englishRaw = String(englishToken).trim();
+      const englishLower = englishRaw.toLowerCase();
+      if (!englishRaw || !prefix) {
+        return match;
+      }
+      // (a) preserve when source line itself contains this english token —
+      // the binding mirrors source structure (e.g. an aside / parenthetical
+      // copy of an English term that is genuinely present in the source).
+      if (sourceLower.includes(englishLower)) {
+        return match;
+      }
+      // (b) preserve when the english matches an anchor required for THIS
+      // line. The anchor's english is the canonical surface form; minor
+      // case / suffix variants are handled by lineAlreadyHasFamilyVariantAnchorParen
+      // in injectAnchorIntoLine, but here we only need to know whether the
+      // english token actually belongs to a binding the model was told to
+      // produce.
+      for (const anchor of lineAnchors) {
+        const candidates = [anchor.english, anchor.chineseHint];
+        if (candidates.some((c) => String(c).toLowerCase() === englishLower)) {
+          return match;
+        }
+        const cl = anchor.english.toLowerCase();
+        if (
+          cl.startsWith(`${englishLower} `) ||
+          cl.endsWith(` ${englishLower}`) ||
+          englishLower.startsWith(`${cl} `) ||
+          englishLower.endsWith(` ${cl}`)
+        ) {
+          return match;
+        }
+      }
+      // Misbinding: drop the parenthetical, keep the leading Chinese phrase.
+      lineChanged = true;
+      return String(prefix);
+    });
+    if (lineChanged) {
+      translatedLines[index] = cleaned;
+      changed = true;
+    }
+  }
+  return changed ? translatedLines.join("\n") : text;
+}
+
 export function injectPlannedAnchorText(
   source: string,
   text: string,

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -17,6 +17,7 @@ import {
 import { DefaultCodexExecutor, type CodexExecOptions, type CodexExecResult, type CodexExecutor } from "./codex-exec.js";
 import {
   applyEmphasisPlanTargets,
+  cleanMisboundAnchorParens,
   applySemanticMentionPlans,
   describeAnchorDisplay,
   formatAnchorDisplay,
@@ -6819,9 +6820,14 @@ async function translateProtectedSegment(
     protectedSource,
     restoredCodeLikeDraftText
   );
+  const misbindCleanedDraftText = cleanMisboundAnchorParens(
+    protectedSource,
+    restoredExampleTokenDraftText,
+    headingPlanningSlice
+  );
   const normalizedDraftSurfaceText = collapseRunawayEnglishAnchorChain(
     normalizeMalformedInlineEnglishEmphasis(
-      normalizeMarkdownLinkLabelWhitespace(restoredExampleTokenDraftText)
+      normalizeMarkdownLinkLabelWhitespace(misbindCleanedDraftText)
     )
   );
   const reprotectedBody = reprotectMarkdownSpans(normalizedDraftSurfaceText, combinedSpans);
@@ -7657,9 +7663,14 @@ async function repairDraftedSegment(
       draftedSegment.protectedSource,
       restoredCodeLikeRepairText
     );
+    const misbindCleanedRepairText = cleanMisboundAnchorParens(
+      draftedSegment.protectedSource,
+      restoredExampleTokenRepairText,
+      headingPlanningSlice
+    );
     const normalizedRepairSurfaceText = collapseRunawayEnglishAnchorChain(
       normalizeMalformedInlineEnglishEmphasis(
-        normalizeMarkdownLinkLabelWhitespace(restoredExampleTokenRepairText)
+        normalizeMarkdownLinkLabelWhitespace(misbindCleanedRepairText)
       )
     );
     const reprotectedRepairBody = reprotectMarkdownSpans(

--- a/test/anchor-normalization.test.ts
+++ b/test/anchor-normalization.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   applyEmphasisPlanTargets,
   applySemanticMentionPlans,
+  cleanMisboundAnchorParens,
   formatAnchorDisplay,
   injectPlannedAnchorText,
   normalizeExplicitRepairAnchorText,
@@ -550,6 +551,69 @@ test("injectPlannedAnchorText does not expand command phrases inside Commands-st
   const normalized = injectPlannedAnchorText(source, translated, slice);
 
   assert.equal(normalized, translated);
+});
+
+test("cleanMisboundAnchorParens removes (English) when English is absent from source line and unrelated to line anchors (loonshots Pan Am↔TWA misbinding)", () => {
+  // Real failure pattern from loonshots chunk 33 line 1003: model wrote
+  // 泛美航空公司（Trans World Airlines）, but the source line is
+  // "Boeing told Trippe that it would build Pan Am a commercial jet" —
+  // Trans World Airlines does not appear on this line and is unrelated
+  // to the Pan Am anchor required here.
+  const slice = createSlice({
+    requiredAnchors: [createAnchor("anchor-1", "Pan Am", "泛美航空")]
+  });
+  const source = "Boeing told Trippe that it would build Pan Am a commercial jet if he would place a firm order.";
+  const translated = "波音告诉特里普会为泛美航空公司（Trans World Airlines）制造一架商用喷气客机。";
+  const cleaned = cleanMisboundAnchorParens(source, translated, slice);
+  assert.equal(cleaned, "波音告诉特里普会为泛美航空公司制造一架商用喷气客机。");
+});
+
+test("cleanMisboundAnchorParens preserves (English) when source line contains the same English token", () => {
+  // The model echoes a parenthetical that genuinely lives in the source
+  // line. Even if there is no anchor for it, we keep the binding.
+  const slice = createSlice({
+    requiredAnchors: [createAnchor("anchor-1", "TWA", "环球航空")]
+  });
+  const source = "American Airlines and Trans World Airlines (TWA) announced their decision.";
+  const translated = "美国航空和环球航空（Trans World Airlines）宣布了决定。";
+  const cleaned = cleanMisboundAnchorParens(source, translated, slice);
+  assert.equal(cleaned, translated);
+});
+
+test("cleanMisboundAnchorParens preserves (English) when English matches a line-required anchor", () => {
+  const slice = createSlice({
+    requiredAnchors: [createAnchor("anchor-1", "Boeing", "波音")]
+  });
+  const source = "Trippe began discussions with Boeing.";
+  const translated = "特里普开始与波音（Boeing）展开讨论。";
+  const cleaned = cleanMisboundAnchorParens(source, translated, slice);
+  assert.equal(cleaned, translated);
+});
+
+test("cleanMisboundAnchorParens is a no-op when the line has no required anchors", () => {
+  // Without a sense of "what should be here", the cleaner stays out — too
+  // risky to delete parentheticals on free-form prose where the model may
+  // be supplying a translator's note.
+  const slice = createSlice({
+    requiredAnchors: []
+  });
+  const source = "Some arbitrary sentence in the source.";
+  const translated = "源文本里某句话（Foo Bar）的中文翻译。";
+  const cleaned = cleanMisboundAnchorParens(source, translated, slice);
+  assert.equal(cleaned, translated);
+});
+
+test("cleanMisboundAnchorParens preserves bilingual canonical with abbreviation suffix", () => {
+  // (English，ABBR) is a legitimate first-mention form. When the source
+  // line carries the English token, the binding stays — abbreviation tail
+  // is consumed by the regex but not checked separately.
+  const slice = createSlice({
+    requiredAnchors: [createAnchor("anchor-1", "Spouse Activation Factor", "配偶激活因子")]
+  });
+  const source = "He coined the term Spouse Activation Factor (SAF) for this dynamic.";
+  const translated = "他把这种现象称为配偶激活因子（Spouse Activation Factor，SAF）。";
+  const cleaned = cleanMisboundAnchorParens(source, translated, slice);
+  assert.equal(cleaned, translated);
 });
 
 test("normalizeExplicitRepairAnchorText restores a quoted-line anchor from an explicit repair target", () => {


### PR DESCRIPTION
## 背景

loonshots 长文译文 chunk 33 出现：

> 波音告诉特里普会为**泛美航空公司（Trans World Airlines）**制造一架商用喷气客机。

原文该行只讲 Pan Am；Trans World Airlines 是 chunk 内后面段才出现的另一家公司。模型在长 chunk 上下文里把 Pan Am 的英文锚定**幻觉**成了别处的术语。

为什么 audit 没抓：Pan Am 已经是 established anchor（chunk 25 首现），\`first_mention_bilingual\` 不去检查这里——audit 漏了"中文锚点 + 无关英文括注"的错绑模式。

为什么 anchor 注入器没纠正：\`lineAlreadyHasFamilyVariantAnchorParen\` 只防重复 + 注入缺失，看到一个不属于自己 family 的 English 括注**会绕开**而不是清理。

## 改动

新增 \`cleanMisboundAnchorParens(source, text, slice)\`：

- 按行迭代 source / translated
- 对每行匹配 \`[一-鿿]+（[A-Za-z][A-Za-z0-9 .+/_\\-]*(?:[，][A-Za-z0-9 .+/_\\-]+)?）\` 形式的括注
- 保留括注的条件（任一即可）：
  - **(a)** source line（小写）含括号内 English token —— 模型在镜像 source 结构
  - **(b)** English 匹配该行某个 required anchor 的 canonical english（含前缀/后缀变体）
- 都不满足 → 错绑 → 移除 \`（English[，ABBR]）\`，保留前面中文短语

保守约束：line 无 required anchors 时直接 no-op（避免误删译者注）。

挂在 chain 收尾位置（\`collapseRunawayEnglishAnchorChain\` 之前），draft + repair 两条路径都加。

## 验证

- 5 个新单测：
  - 错绑移除（loonshots Pan Am↔TWA 真实复现）
  - source line 含 English 时保留
  - 命中 line required anchor 时保留
  - 无 line anchors 时 no-op
  - 首现锚定 \`（English，ABBR）\` 形式保留
- \`npm run verify\` 314/314 全绿

## 关联

- 上游：PR #105（双层括号 anchor 注入修复）— 双重保险，那个修的是"防重复注入"，这个修的是"清理已经存在的错绑"
- 下游：重跑 loonshots 应该消除 chunk 33 的 Pan Am↔TWA 错绑；其它叙事密集长文里类似错绑也会被清掉

🤖 Generated with [Claude Code](https://claude.com/claude-code)