### PR TITLE
feat: checkpoint resume 支持 sparse 模式（按 chunkId 任意子集）

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -2873,24 +2873,28 @@ export async function translateMarkdownArticle(source: string, options: Translat
     if (checkpointDir && checkpointKey) {
       const checkpoint = await readTranslationCheckpoint(checkpointDir, checkpointKey);
       if (checkpoint) {
-        const isPrefixCheckpoint = checkpoint.completedChunks.every((entry, index) => {
-          const chunk = chunkPlan.chunks[index];
-          return chunk ? entry.chunkId === `chunk-${chunk.index + 1}` : false;
-        });
+        // Sparse checkpoints are valid: as long as every checkpointed chunkId
+        // resolves to a chunk in the current plan, we can resume any subset of
+        // completed chunks (e.g. when retry-failed-chunks selectively drops
+        // soft-fallback entries from the checkpoint to re-translate them
+        // without redoing the whole book). The finalize loop below already
+        // checks `completedCheckpointChunks.some(...)` per index, so it can
+        // weave checkpoint bodies and worker-produced bodies together in plan
+        // order. Resume only needs to import the run-level state and seed
+        // completedCheckpointChunks here; the finalize loop will push each
+        // restored body into restoredChunks at the right index.
+        const planChunkIds = new Set(
+          chunkPlan.chunks.map((chunk) => `chunk-${chunk.index + 1}`)
+        );
+        const allCheckpointIdsKnown = checkpoint.completedChunks.every((entry) =>
+          planChunkIds.has(entry.chunkId)
+        );
 
-        if (isPrefixCheckpoint) {
+        if (allCheckpointIdsKnown) {
           state = checkpoint.state;
           repairCyclesUsed = checkpoint.repairCyclesUsed;
           nextLocalSpanIndex = checkpoint.nextLocalSpanIndex;
           completedCheckpointChunks.push(...checkpoint.completedChunks);
-          for (const [index, completedChunk] of checkpoint.completedChunks.entries()) {
-            const chunk = chunkPlan.chunks[index];
-            if (!chunk) {
-              continue;
-            }
-            restoredChunks.push(completedChunk.body + chunk.separatorAfter);
-            gateAudits.push(completedChunk.gateAudit);
-          }
           report(
             options,
             "draft",
@@ -3120,7 +3124,19 @@ export async function translateMarkdownArticle(source: string, options: Translat
           const outcome = chunkOutcomes[nextChunkToFinalize];
           const finalizingChunk = chunkPlan.chunks[nextChunkToFinalize]!;
           if (!outcome) {
-            // Already restored from checkpoint — nothing to do beyond skipping.
+            // Restored from checkpoint — push its body into restoredChunks at
+            // this plan index so the final document weaves checkpoint bodies
+            // and worker-produced bodies together in plan order. Sparse
+            // checkpoints (retry-failed-chunks workflow) rely on this; for
+            // contiguous prefix checkpoints it produces the same final
+            // document as the previous "push during resume" behaviour.
+            const checkpointEntry = completedCheckpointChunks.find(
+              (entry) => entry.chunkId === `chunk-${finalizingChunk.index + 1}`
+            );
+            if (checkpointEntry) {
+              restoredChunks.push(checkpointEntry.body + finalizingChunk.separatorAfter);
+              gateAudits.push(checkpointEntry.gateAudit);
+            }
             nextChunkToFinalize += 1;
             continue;
           }

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -3081,6 +3081,129 @@ test("translateMarkdownArticle resumes completed chunks from a persisted checkpo
   }
 });
 
+test("translateMarkdownArticle resumes a sparse checkpoint and only re-translates the missing chunks", async () => {
+  // Sparse-checkpoint resume: simulate the retry-failed-chunks workflow by
+  // dropping one chunk's entry from the checkpoint between runs. The second
+  // run should retranslate only that chunk and reuse the rest from
+  // checkpoint.
+  // Pad each section so the planner cuts at least 2 chunks.
+  const padding = "Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor.\n\n".repeat(20);
+  const source = ["## One", "", padding, "## Two", "", padding].join("\n");
+  const tempDir = await mkdtemp(path.join(tmpdir(), "mdzh-sparse-checkpoint-"));
+  const checkpointDir = path.join(tempDir, "checkpoint");
+  const progressMessages: string[] = [];
+
+  class CheckpointExecutor implements CodexExecutor {
+    analysisCalls = 0;
+    contentCalls = 0;
+    chunkSourceSeen: string[] = [];
+
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        this.analysisCalls += 1;
+        return createExecResult(createEmptyAnchorCatalog());
+      }
+      if (options.outputSchema && prompt.includes("### BLOCK 1")) {
+        this.contentCalls += 1;
+        const sourceSection = extractPromptSection(prompt, "【按块展开的英文原文】") ?? "";
+        if (sourceSection) this.chunkSourceSeen.push(sourceSection);
+        const blockCount = (prompt.match(/^### BLOCK \d+ \([^)]+\)$/gm) ?? []).length;
+        return createExecResult(
+          JSON.stringify({
+            blocks: Array.from({ length: Math.max(1, blockCount) }, (_, index) => `块 ${index + 1}`)
+          })
+        );
+      }
+      if (options.outputSchema || prompt.includes('"hard_checks"') || prompt.includes("只返回 JSON")) {
+        this.contentCalls += 1;
+        return createExecResult(wrapAuditForSegments(prompt, createAudit(true)));
+      }
+      const currentTranslation = extractPromptSection(prompt, "【当前译文】");
+      if (currentTranslation !== null) {
+        this.contentCalls += 1;
+        return createExecResult(currentTranslation);
+      }
+      const sourceSection = extractPromptSection(prompt, "【英文原文】");
+      this.contentCalls += 1;
+      return createExecResult(sourceSection ?? "");
+    }
+  }
+
+  const firstExecutor = new CheckpointExecutor();
+  const secondExecutor = new CheckpointExecutor();
+
+  try {
+    await translateMarkdownArticle(source, {
+      executor: firstExecutor,
+      formatter: async (markdown) => markdown,
+      sourcePathHint: "sparse-checkpoint.md",
+      checkpointDir,
+      disableAnalysisCache: true
+    });
+
+    // Manually strip chunk-1's entry from the checkpoint so the second run
+    // sees a sparse checkpoint (chunks: [chunk-2] only).
+    const fs = await import("node:fs/promises");
+    const files = await fs.readdir(checkpointDir);
+    const checkpointFile = files.find((f) => f.endsWith(".json"));
+    assert.ok(checkpointFile, "checkpoint file should exist after first run");
+    const checkpointPath = path.join(checkpointDir, checkpointFile!);
+    const checkpoint = JSON.parse(await fs.readFile(checkpointPath, "utf8"));
+    const before = checkpoint.completedChunks.length;
+    assert.ok(before >= 2, `first run should have produced ≥2 completed chunks, got ${before}: ${JSON.stringify(checkpoint.completedChunks.map((c: { chunkId: string }) => c.chunkId))}`);
+    checkpoint.completedChunks = checkpoint.completedChunks.filter(
+      (c: { chunkId: string }) => c.chunkId !== "chunk-1"
+    );
+    assert.equal(checkpoint.completedChunks.length, before - 1, "expected to strip chunk-1 entry");
+    await fs.writeFile(checkpointPath, JSON.stringify(checkpoint), "utf8");
+
+    const result = await translateMarkdownArticle(source, {
+      executor: secondExecutor,
+      formatter: async (markdown) => markdown,
+      sourcePathHint: "sparse-checkpoint.md",
+      checkpointDir,
+      disableAnalysisCache: true,
+      onProgress: (message) => progressMessages.push(message)
+    });
+
+    // Second run should resume the sparse checkpoint (before-1 entries left)
+    // and only retranslate chunk-1.
+    const expectedRemaining = before - 1;
+    const resumeMatcher = new RegExp(
+      `Resumed translation checkpoint with ${expectedRemaining} completed chunk\\(s\\)`
+    );
+    assert.match(progressMessages.join("\n"), resumeMatcher);
+    // Each remaining checkpoint chunk must produce a "Skipping ...; restored
+    // from checkpoint." log on the second run; chunk-1 must NOT skip (it has
+    // to be retranslated).
+    const secondRunProgress = progressMessages.slice(progressMessages.length - 30);
+    const skippedIds = secondRunProgress
+      .filter((m) => /Skipping chunk-\d+; restored from checkpoint/.test(m))
+      .map((m) => m.match(/Skipping (chunk-\d+);/)?.[1] ?? "");
+    assert.ok(skippedIds.length === expectedRemaining, `expected ${expectedRemaining} chunks restored from checkpoint, got ${skippedIds.length}: ${skippedIds.join(",")}`);
+    assert.ok(!skippedIds.includes("chunk-1"), "chunk-1 must NOT be skipped — it was stripped from checkpoint");
+    assert.ok(
+      secondExecutor.contentCalls > 0,
+      "expected the missing chunk to trigger retranslation"
+    );
+    // The final body must still contain content from every chunk in plan
+    // order — the freshly retranslated chunk woven with the checkpoint
+    // bodies. Mock executor produces "块 N" placeholders for each source
+    // block, so the document should contain a continuous sequence of those
+    // (one set per chunk-1 worker output, then the restored bodies).
+    assert.ok(result.markdown.length > 0, "result markdown must not be empty");
+    // Output must contain at least as many distinct "块 N" placeholders as
+    // there are chunks (one set from each chunk's body / restored body).
+    const blockMatches = result.markdown.match(/块\s+\d+/g) ?? [];
+    assert.ok(
+      blockMatches.length >= before,
+      `expected at least ${before} block placeholders in output (one per chunk), got ${blockMatches.length}`
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("translateMarkdownArticle strips hook prompt control-text contamination before audit", async () => {
   const source = "Plain body.\n";
   const executor: CodexExecutor = {


### PR DESCRIPTION
## 背景

之前 \`isPrefixCheckpoint\` 强制要求 \`checkpoint.completedChunks\` 是从 chunk-1 开始的连续前缀；不满足时 pipeline 整个忽略 checkpoint 从头跑。

\`retry-failed-chunks\` 工作流的核心需求：用户从 checkpoint 删掉 N 个 soft-fallback chunks 的 entry，重跑只翻这 N 个，其它走 cache。删除让 checkpoint 变 sparse（中间有空洞），prefix-only 校验直接跳过，浪费整本重跑的成本。

实测在 loonshots 长文上：手动 strip 11 个 fallback chunks 想只翻它们，但 prefix-only 让 pipeline 重跑全本 134 chunks。

## 改动

\`src/translate.ts\`：

- \`isPrefixCheckpoint\` → \`allCheckpointIdsKnown\`：只要每个 entry 的 \`chunkId\` 都对应 \`chunkPlan\` 里的某个 chunk，就允许 resume。前缀连续性不再要求。
- Resume 阶段不再 push 到 \`restoredChunks\`（之前 prefix push 的逻辑）；改成全部交给 finalize loop 在 plan 顺序遍历时处理。
- finalize loop 的 \`!outcome\` 分支从"跳过"改成"push checkpoint body 然后推进"，让 sparse 部分也能正确织入最终文档。

## 验证

新单测 \`translateMarkdownArticle resumes a sparse checkpoint and only re-translates the missing chunks\`：
- 第一次 run 写完整 checkpoint
- 手动 strip chunk-1 entry 让 checkpoint 变 sparse
- 第二次 run 验证：
  - progress 报 "Resumed... N completed chunk(s)"（N = before - 1）
  - 剩余 chunks 都触发 "Skipping chunk-X; restored from checkpoint."
  - chunk-1 不在 skipped 列表里（被重译）
  - 最终 output 含每个 chunk 的产出（block 占位符数量 ≥ chunk 总数）

老测试 \`resumes completed chunks from a persisted checkpoint\` 覆盖前缀完整 checkpoint，仍然通过——证明 prefix-only 路径产出的文档跟修改前一致。

\`npm run verify\` 315/315 全绿。

## 用法

\`\`\`python
# 删除指定 chunks 的 entry 让它们被重译
import json
with open('checkpoint/<key>.json') as f:
    cp = json.load(f)
cp['completedChunks'] = [c for c in cp['completedChunks'] if c['chunkId'] not in {'chunk-8', 'chunk-23', 'chunk-39'}]
with open('checkpoint/<key>.json', 'w') as f:
    json.dump(cp, f)
# 重跑 cli — 删掉的 chunks 重译，其它走 cache
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)