### PR TITLE
docs: loonshots 7 个稳定 fallback chunks 收编为 case study + fixture

### DIFF
--- a/docs/translation-resilience-plan.md
+++ b/docs/translation-resilience-plan.md
@@ -128,3 +128,40 @@ function alignSkeletons(source: StructuralSkeleton, draft: StructuralSkeleton):
 - TM 跨 doc 命中、fuzzy match：Phase 4 v1 已落地够用，等 v1 在生产积累足量数据再说
 - analysis 的并行化：21 shards 串行是真实瓶颈但与本轮主题无关
 - 列表 token 级 streaming / 部分 chunk 续译：观察期之后再判断
+
+## 7. Loonshots Case Study（2026-04-29 ~ 04-30）
+
+整本《Loonshots》（728 KB / 134 chunks）跑完一次后，7 个 chunks 在多次重试中**稳定 fallback to source**——repair 5.5、rescue 5.5 都救不回。每一轮都是同样集合，证明不是随机失败而是当前模型 + 当前 prompt 形态下的真实能力边界。
+
+### 硬骨头清单
+
+| chunk | source 大小 | heading | 主要失败模式 |
+|---|---|---|---|
+| 14 | 4.3 KB | 1 § ONE AT A TIME | 段落重复（第 4-5 段重复 1-2 段）+ 漏译 Radar 段 + V-1 段 |
+| 30 | 8.2 KB | 3 § JT AND LINDY | 段落英文残留（第 3-5 段未译）+ 漏末尾 China Clipper 段 |
+| 54 | 6.1 KB | 5 § HOW TO WIN AT CHESS | 段落重复 + 漏末尾 Xerox PARC 段 + 多处首现锚点缺失 |
+| 69 | 2.9 KB | 6 § WHEN TERROR GOES VIRAL | 末尾重复"狱卒"段 + 缺 Joseph Smith 段 |
+| 72 | 4.3 KB | 7 § THE INVISIBLE AXE | 第 6-9 段重复追加第 2-5 段（整组 4 段重复）|
+| 91 | 7.1 KB | 9 § DRUGS | image placeholder `@@MDZH_IMAGE_DESTINATION_0095@@` 被复制（found 2 expected 1）|
+| 109 | 10.4 KB | Source Notes § INTRODUCTION | draft 返回 meta/audit text（模型在 reference notes 这种密集列表上偷懒）|
+
+### 共同失败签名
+
+- **段落级幻觉**（chunks 14 / 30 / 54 / 69 / 72）：模型在 ≥ 4 KB 的叙事密集 segment 上重复段落、漏译段落、跨段错位。Audit 报 `paragraph_match` 失败，repair / rescue 都救不回。
+- **placeholder 复制**（chunk 91）：image 占位符被错误地复制到译文不同位置，触发 `protected_span_integrity` 失败。
+- **draft 返工/偷懒**（chunk 109）：source 是密集 reference list，模型 draft 阶段返回元话语而非翻译内容（可能识别成"审校提示"而非翻译任务）。
+
+### 已尝试但救不回的手段
+
+- repair 默认升 gpt-5.5（PR #105）—— 带 audit must_fix 的强模型修复
+- rescue 整 chunk 用 gpt-5.5 重做（PR #92）
+- json-blocks 严格 retry 不再 fallback freeform（PR #104）
+- anchor 错绑清理 `cleanMisboundAnchorParens`（PR #107）
+
+### 处置
+
+走 §3.3 「接受能力边界」路径：
+- soft-gate 真"软"（PR #106）让这 7 个 chunks fallback to source（保留英文段），整本书 95%+ 中文，结构完整可读
+- 不为这 7 个 chunks 开新 patch——叠加到已有的 cleanMisbound / dedup / aligner 之上不再有边际改进
+- 等模型升级后回来 retry 验证（sparse-checkpoint-resume PR #108 让 retry 成本低，sparse 路径只翻这 7 个，~18 分钟 vs 全本重跑 ~120 分钟）
+- 总览 fixture：`test/fixtures/resilience/loonshots-narrative-paragraph-hallucination.md`

--- a/test/fixtures/resilience/loonshots-narrative-paragraph-hallucination.md
+++ b/test/fixtures/resilience/loonshots-narrative-paragraph-hallucination.md
@@ -1,0 +1,98 @@
+---
+title: "loonshots narrative paragraph hallucination (chunks 14/30/54/69/72/91/109)"
+source: "loonshots.md (728 KB / 134 chunks)"
+observed_runs:
+  - 2026-04-29 (PR #103/#104/#105/#106): 11 fallback chunks
+  - 2026-04-30 (PR #107 cleanMisbound): 7 fallback chunks (chunks 14/30/54/69/72/91/109)
+  - 2026-04-30 sparse retry: 7 fallback chunks (same set, confirmed deterministic)
+stable_failures:
+  - chunk-14 (ONE AT A TIME, 4.3KB): paragraph repetition + missing radar/V-1 paragraphs
+  - chunk-30 (JT AND LINDY, 8.2KB): English residue in segments 3-5 + missing China Clipper paragraph
+  - chunk-54 (HOW TO WIN AT CHESS, 6.1KB): paragraph repetition + missing final Xerox PARC paragraph
+  - chunk-69 (WHEN TERROR GOES VIRAL, 2.9KB): tail paragraph duplication + missing Joseph Smith paragraph
+  - chunk-72 (THE INVISIBLE AXE, 4.3KB): wholesale duplication (paragraphs 6-9 copy paragraphs 2-5)
+  - chunk-91 (DRUGS, 7.1KB): image placeholder duplication (@@MDZH_IMAGE_DESTINATION_0095@@ x2)
+  - chunk-109 (Source Notes / INTRODUCTION, 10.4KB): draft returns meta/audit text instead of translation
+remedies_tried_and_failed:
+  - repair model default gpt-5.5 (PR #105)
+  - rescue model gpt-5.5 (PR #92)
+  - json-blocks no-fallback-to-freeform (PR #104)
+  - cleanMisboundAnchorParens (PR #107)
+  - structural skeleton aligner (PR #100/101/102)
+disposition:
+  - accept as model capability boundary
+  - soft-gate fallback-to-source preserves structure (PR #106)
+  - sparse-checkpoint-resume (PR #108) makes future retry cheap (~18 min vs ~2 hr)
+  - revisit when codex CLI exposes a stronger model
+---
+
+# loonshots narrative paragraph hallucination
+
+This fixture is a **summary marker**, not a runnable reproduction. The actual
+chunks are too large (~50 KB total) to inline; they live in
+`/Users/rongshen/vibe-coding/free-research/loonshots_markdown/loonshots.md`
+under their respective headings (see `stable_failures` above).
+
+## Why fixture-only, not a code fix
+
+Every code-level remedy we have lands at this set's boundary:
+
+- **Section reordering / paragraph dropping**: detectable by `paragraph_match`
+  hard check, but neither repair (with explicit must_fix instructions) nor
+  rescue (clean restart with stronger model) can recover. The model commits
+  to a wrong segment shape on first draft and re-emits the same shape on
+  retries, presumably because the prompt-cached context anchors it to the
+  same hallucinated layout.
+
+- **Image placeholder duplication** (chunk-91): the protected-span integrity
+  check catches it but anchor injection / dedup utilities cannot remove a
+  duplicate that the model placed at a structurally legitimate location.
+
+- **Meta / audit text leakage** (chunk-109): the source is dense
+  reference-style notes (book bibliography). The model interprets the
+  request as "audit this" rather than "translate this" and returns control
+  text. Draft contract `getDraftContractViolation` rejects each attempt;
+  strict retry hits the same trap.
+
+These failures are stable across runs (same 7 chunks fallback every time),
+so the fixture's job is to:
+
+1. Document the boundary so future contributors don't re-run the same
+   patches against the same problems.
+2. Provide a re-evaluation point when the underlying model improves —
+   re-translate just these 7 chunks with the sparse-checkpoint-resume
+   workflow (PR #108) and see whether the new model crosses the boundary.
+
+## Sparse retry recipe
+
+When a stronger model becomes available:
+
+```bash
+# 1. Identify the latest checkpoint key for loonshots.md
+node scripts/recompute-cache-key.mjs  # or compute manually
+
+# 2. Strip the 7 stable-failure chunks from the checkpoint
+python3 -c "
+import json, sys
+cp_path = sys.argv[1]
+with open(cp_path) as f: cp = json.load(f)
+cp['completedChunks'] = [c for c in cp['completedChunks']
+                          if c['chunkId'] not in
+                          {'chunk-14','chunk-30','chunk-54','chunk-69',
+                           'chunk-72','chunk-91','chunk-109'}]
+with open(cp_path, 'w') as f: json.dump(cp, f, ensure_ascii=False)
+" /tmp/mdzh-loonshots/checkpoint/<key>.json
+
+# 3. Re-run with the new model
+TRANSLATION_MODEL=<new-model> \
+MDZH_CHECKPOINT_DIR=/tmp/mdzh-loonshots/checkpoint \
+MDZH_ANALYSIS_CACHE_DIR=/tmp/mdzh-loonshots/analysis-cache \
+MDZH_SOFT_GATE=true \
+node dist/src/cli.js \
+  --input /Users/rongshen/vibe-coding/free-research/loonshots_markdown/loonshots.md \
+  --output /Users/rongshen/vibe-coding/free-research/loonshots_markdown/loonshots.zh.md
+```
+
+Sparse resume will reuse 127 chunks from cache and only retranslate the 7.
+If any fall out of the failure set, that's a real model-capability win and
+this fixture's `observed_runs` should be appended to.


### PR DESCRIPTION
## 背景

整本 Loonshots（728 KB / 134 chunks）在多次重试中，**7 个 chunks 稳定 fallback to source**：14 / 30 / 54 / 69 / 72 / 91 / 109。

确认这是 deterministic 失败集合（不是随机）：
- 2026-04-29（PR #103/#104/#105/#106 全部应用）：11 fallback
- 2026-04-30（PR #107 anchor cleanMisbound 应用）：7 fallback
- 2026-04-30 sparse retry（PR #108 验证）：仍是同样 7 个

repair gpt-5.5、rescue gpt-5.5、json-blocks 拒 freeform、anchor 错绑清理 都救不回。

## 改动

按 resilience plan §3.3「接受能力边界 + 失败收编为 fixture」走：

**文档**（`docs/translation-resilience-plan.md` 新增 §7 Loonshots Case Study）：
- 硬骨头清单（chunk + 大小 + heading + 失败模式）
- 共同失败签名（段落级幻觉 / placeholder 复制 / draft 元话语）
- 已尝试无效的 remedy 列表
- 处置方案：accept boundary + sparse retry 等模型升级

**fixture**（`test/fixtures/resilience/loonshots-narrative-paragraph-hallucination.md`）：
- 总览 marker（不内联实际 source，引用绝对路径）
- sparse-retry recipe 供未来回来验证
- frontmatter 记录 observed_runs / stable_failures / remedies_tried_and_failed / disposition

## 不做的

- 不再为这 7 个 chunks 加新 patch——再叠加无边际改进
- 不实施代码改动——纯文档归档

## 关联

- 上游：PR #103-#108 整套 resilience 修复
- 下游：模型升级时用 PR #108 sparse-checkpoint-resume 仅重译这 7 个（~18 min vs ~120 min 全本）

🤖 Generated with [Claude Code](https://claude.com/claude-code)