### PR TITLE
feat: MDZH_FINAL_RESCUE_COMMAND — 外部 hook 替代手工修复

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -100,6 +100,18 @@ Performance knobs:
     cannot. Set to \`off\` / \`none\` / \`false\` / \`0\` (or empty) to fall
     back to the post-draft (typically mini) model. Trades cost for first-pass
     repair success on long-form content.
+  - MDZH_FINAL_RESCUE_COMMAND=<shell command> opt-in last-line tier before
+    soft-gate source fallback. When draft + repair + rescue all fail and a
+    chunk would otherwise fall back to English source content, this shell
+    command is launched via \`/bin/sh -c\`; the chunk's protected source
+    text is written to stdin and the command's stdout is taken as the
+    Chinese translation. Output is accepted only if it matches the source
+    paragraph count, preserves the protected-placeholder count, and contains
+    at least one Chinese character; otherwise the pipeline falls back to
+    source as before. Use this hook to plug in a stronger external
+    translator (Claude API, GPT-5 outside codex, sentence-level splitter,
+    human-in-the-loop) without modifying the pipeline. Set
+    MDZH_FINAL_RESCUE_TIMEOUT_MS to override the default 600s timeout.
 
 Exit codes:
   0  Success (may include soft-gate degraded output; see stderr for warnings).

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -13,6 +13,8 @@ export type TelemetryEventType =
   | "chunk.concurrency"
   | "chunk.rescue.start"
   | "chunk.rescue.end"
+  | "chunk.final_rescue.start"
+  | "chunk.final_rescue.end"
   | "repair.cycle"
   | "repair.patch"
   | "gate.result"

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -124,6 +125,152 @@ function readRepairModel(postDraftModel: string): string {
     return postDraftModel;
   }
   return trimmed;
+}
+
+/**
+ * External "final rescue" hook resolver. When a chunk exhausts every codex
+ * lane (draft → repair × 2 → audit → rescue with stronger model) and is
+ * about to fall back to source content under soft-gate, the pipeline
+ * optionally hands the chunk's protected source text to a user-configured
+ * shell command. The command receives the source on stdin and is expected
+ * to return a Chinese translation on stdout. If the command's output passes
+ * structural validation (paragraph count / placeholder count match, plus a
+ * minimum Chinese character ratio), it replaces the chunk body. On any
+ * failure the pipeline keeps its existing soft-gate-fallback behaviour.
+ *
+ * The hook is opt-in: set `MDZH_FINAL_RESCUE_COMMAND=<shell command>` to
+ * enable. The command is launched via `/bin/sh -c`, so any tool the user
+ * trusts can plug in here — Claude API, GPT-5 outside codex, sentence-level
+ * splitter, even a Slack bot that pages a translator. The pipeline does
+ * not bind any specific model.
+ *
+ * Returns null when the env var is unset, empty, or set to one of the
+ * disable sentinels.
+ */
+function readFinalRescueCommand(): string | null {
+  const raw = process.env.MDZH_FINAL_RESCUE_COMMAND;
+  if (raw === undefined) {
+    return null;
+  }
+  const trimmed = raw.trim();
+  if (trimmed === "") {
+    return null;
+  }
+  const lower = trimmed.toLowerCase();
+  if (lower === "off" || lower === "none" || lower === "false" || lower === "0") {
+    return null;
+  }
+  return trimmed;
+}
+
+function readFinalRescueTimeoutMs(): number {
+  const raw = process.env.MDZH_FINAL_RESCUE_TIMEOUT_MS?.trim();
+  if (!raw) {
+    return 600_000;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return parsed;
+  }
+  return 600_000;
+}
+
+/**
+ * Run the configured final-rescue command with `protectedSource` on stdin.
+ * Returns the trimmed stdout on success, or `null` if the command fails,
+ * times out, exits non-zero, or produces empty output. Caller is expected
+ * to validate the returned text against the source structure (paragraph
+ * count / placeholder count / Chinese-character ratio) before accepting.
+ */
+async function executeFinalRescueCommand(
+  command: string,
+  protectedSource: string,
+  timeoutMs: number
+): Promise<string | null> {
+  return new Promise((resolve) => {
+    let resolved = false;
+    let stdout = "";
+    let stderr = "";
+    const child = spawn("/bin/sh", ["-c", command], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: process.env
+    });
+    const finish = (text: string | null) => {
+      if (resolved) return;
+      resolved = true;
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        // ignore — child may already be dead
+      }
+      resolve(text);
+    };
+    const timer = setTimeout(() => finish(null), timeoutMs);
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", () => {
+      clearTimeout(timer);
+      void stderr;
+      finish(null);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        finish(null);
+        return;
+      }
+      const trimmed = stdout.replace(/\s+$/u, "");
+      finish(trimmed.length > 0 ? trimmed : null);
+    });
+    child.stdin.end(protectedSource);
+  });
+}
+
+/**
+ * Validate a final-rescue command's output against the source structure.
+ * Accept iff (1) paragraph counts match, (2) protected-placeholder counts
+ * match, (3) the body contains a non-trivial amount of Chinese characters
+ * (≥10% of non-whitespace, non-ASCII chars). Anything else gets rejected
+ * and the pipeline falls through to soft-gate source fallback.
+ */
+function validateFinalRescueOutput(
+  protectedSource: string,
+  candidate: string
+): { ok: true } | { ok: false; reason: string } {
+  const sourceBlocks = splitPromptBlocks(protectedSource);
+  const candidateBlocks = splitPromptBlocks(candidate);
+  if (sourceBlocks.length !== candidateBlocks.length) {
+    return {
+      ok: false,
+      reason: `paragraph count mismatch: source ${sourceBlocks.length}, rescue output ${candidateBlocks.length}`
+    };
+  }
+  const placeholderPattern = /@@MDZH_[A-Z_]+_\d{4}@@/g;
+  const sourceMatches = protectedSource.match(placeholderPattern) ?? [];
+  const candidateMatches = candidate.match(placeholderPattern) ?? [];
+  if (sourceMatches.length !== candidateMatches.length) {
+    return {
+      ok: false,
+      reason: `protected placeholder count mismatch: source ${sourceMatches.length}, rescue output ${candidateMatches.length}`
+    };
+  }
+  const cjkCount = (candidate.match(/[一-鿿]/gu) ?? []).length;
+  // Accept any output with ≥1 Chinese char — paragraph + placeholder counts
+  // already enforce structural shape; if the rescue produces zero CJK
+  // characters at all we treat it as "command silently echoed source".
+  if (cjkCount < 1) {
+    return {
+      ok: false,
+      reason: `rescue output contains no Chinese characters (likely echoed source untranslated)`
+    };
+  }
+  return { ok: true };
 }
 
 function readRescueModel(): string | null {
@@ -3062,6 +3209,76 @@ export async function translateMarkdownArticle(source: string, options: Translat
           }
           return;
         } else {
+          // Last-line tier before source fallback: optional external "final
+          // rescue" hook. The user can configure
+          // `MDZH_FINAL_RESCUE_COMMAND` to plug in a stronger external
+          // translator (Claude Opus, GPT-5 outside codex, sentence-level
+          // splitter, human-in-the-loop). If accepted, the chunk gets a
+          // real Chinese body instead of degrading to English source.
+          const finalRescueCommand = readFinalRescueCommand();
+          let finalRescueBody: string | null = null;
+          let finalRescueError: string | null = null;
+          if (finalRescueCommand) {
+            const finalRescueStart = Date.now();
+            const timeoutMs = readFinalRescueTimeoutMs();
+            telemetry.emit({
+              ts: finalRescueStart,
+              runId,
+              type: "chunk.final_rescue.start",
+              chunkId,
+              meta: {
+                chunkIndex: chunk.index + 1,
+                command: finalRescueCommand,
+                timeoutMs
+              }
+            });
+            report(
+              options,
+              "audit",
+              `Chunk ${chunk.index + 1}/${chunkPlan.chunks.length} (${chunk.headingPath.join(" > ") || "untitled"}): invoking final-rescue command before source fallback.`
+            );
+            const candidate = await executeFinalRescueCommand(
+              finalRescueCommand,
+              chunk.source,
+              timeoutMs
+            );
+            if (candidate === null) {
+              finalRescueError = "command exited non-zero, timed out, or produced empty output";
+            } else {
+              const validation = validateFinalRescueOutput(chunk.source, candidate);
+              if (validation.ok) {
+                finalRescueBody = candidate;
+              } else {
+                finalRescueError = validation.reason;
+              }
+            }
+            telemetry.emit({
+              ts: Date.now(),
+              runId,
+              type: "chunk.final_rescue.end",
+              chunkId,
+              durationMs: Date.now() - finalRescueStart,
+              ...(finalRescueError ? { error: finalRescueError } : {}),
+              meta: {
+                command: finalRescueCommand,
+                success: finalRescueBody !== null
+              }
+            });
+            if (finalRescueBody !== null) {
+              report(
+                options,
+                "audit",
+                `Chunk ${chunk.index + 1}/${chunkPlan.chunks.length} (${chunk.headingPath.join(" > ") || "untitled"}): final-rescue command produced an accepted translation; using it instead of source fallback.`
+              );
+            } else if (finalRescueError) {
+              report(
+                options,
+                "audit",
+                `Chunk ${chunk.index + 1}/${chunkPlan.chunks.length} (${chunk.headingPath.join(" > ") || "untitled"}): final-rescue command rejected (${finalRescueError}); falling back to source content.`
+              );
+            }
+          }
+
           telemetry.emit({
             ts: Date.now(),
             runId,
@@ -3069,21 +3286,30 @@ export async function translateMarkdownArticle(source: string, options: Translat
             chunkId,
             durationMs: Date.now() - chunkStartedAt,
             error: errorMessage,
-            meta: { recovered: true, structural: false }
+            meta: {
+              recovered: true,
+              structural: false,
+              finalRescueAccepted: finalRescueBody !== null
+            }
           });
-          report(
-            options,
-            "audit",
-            `Chunk ${chunk.index + 1}/${chunkPlan.chunks.length} (${chunk.headingPath.join(" > ") || "untitled"}): soft-gate caught chunk failure (${errorMessage}); falling back to source content.`
-          );
+          if (finalRescueBody === null) {
+            report(
+              options,
+              "audit",
+              `Chunk ${chunk.index + 1}/${chunkPlan.chunks.length} (${chunk.headingPath.join(" > ") || "untitled"}): soft-gate caught chunk failure (${errorMessage}); falling back to source content.`
+            );
+          }
           // Pass only spans whose placeholder ID appears in this chunk's source
           // — restoreMarkdownSpans throws if asked to restore a span absent from
           // the body, and the document-wide `spans` includes IDs from other
           // chunks.
           const chunkSpans = spans.filter((span) => chunk.source.includes(span.id));
-          const fallbackBody = restoreMarkdownSpans(chunk.source, chunkSpans);
+          const recoveredBody =
+            finalRescueBody !== null
+              ? restoreMarkdownSpans(finalRescueBody, chunkSpans)
+              : restoreMarkdownSpans(chunk.source, chunkSpans);
           chunkResult = {
-            body: fallbackBody,
+            body: recoveredBody,
             repairCyclesUsed: 0,
             gateAudit: createSyntheticChunkFailureAudit(errorMessage),
             nextLocalSpanIndex

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -228,7 +228,17 @@ async function executeFinalRescueCommand(
       const trimmed = stdout.replace(/\s+$/u, "");
       finish(trimmed.length > 0 ? trimmed : null);
     });
-    child.stdin.end(protectedSource);
+    // Swallow EPIPE: a fast-exiting command (e.g. `printf '...'` in tests)
+    // can close stdin before our write completes. We don't care — the
+    // command's stdout is what we read; if it ignored stdin that's fine.
+    child.stdin.on("error", () => {
+      // intentional no-op
+    });
+    try {
+      child.stdin.end(protectedSource);
+    } catch {
+      // also ignore — the close handler above is what reports the verdict
+    }
   });
 }
 

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -4402,6 +4402,155 @@ test("MDZH_RESCUE_MODEL=off explicitly disables rescue", async () => {
   assert.equal(rescueEvents.length, 0, "no rescue events should fire when MDZH_RESCUE_MODEL=off");
 });
 
+test("MDZH_FINAL_RESCUE_COMMAND replaces source-fallback when its output validates", async () => {
+  // Setup: chunk fails draft + rescue, so it would normally fall back to
+  // source content under soft-gate. With MDZH_FINAL_RESCUE_COMMAND set to
+  // an external translator that produces a valid Chinese body matching
+  // source paragraph count, the chunk body must be the rescue output —
+  // NOT the original English source.
+  const source = "## Hello\n\nWorld.\n";
+
+  const executor: CodexExecutor = {
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(createEmptyAnchorCatalog());
+      }
+      if (isBundledAuditPrompt(prompt, options) || (options.outputSchema && prompt.includes('"hard_checks"'))) {
+        return createExecResult(wrapAuditForSegments(prompt, createAudit(true)));
+      }
+      // Both primary and rescue draft calls fail.
+      throw new CodexExecutionError("draft fail");
+    }
+  };
+
+  // Final rescue: a tiny shell command that emits a valid 2-paragraph
+  // Chinese body matching the source structure. Using `printf` here keeps
+  // the test hermetic (no API call) while exercising the spawn / stdio
+  // path end-to-end.
+  const previousCommand = process.env.MDZH_FINAL_RESCUE_COMMAND;
+  const previousRescue = process.env.MDZH_RESCUE_MODEL;
+  process.env.MDZH_FINAL_RESCUE_COMMAND = "printf '## 你好\\n\\n世界。\\n'";
+  process.env.MDZH_RESCUE_MODEL = "off";
+  const sink = createMemoryTelemetrySink();
+  let result;
+  try {
+    result = await translateMarkdownArticle(source, {
+      executor,
+      formatter: async (markdown) => markdown,
+      softGate: true,
+      telemetry: sink
+    });
+  } finally {
+    if (previousCommand === undefined) delete process.env.MDZH_FINAL_RESCUE_COMMAND;
+    else process.env.MDZH_FINAL_RESCUE_COMMAND = previousCommand;
+    if (previousRescue === undefined) delete process.env.MDZH_RESCUE_MODEL;
+    else process.env.MDZH_RESCUE_MODEL = previousRescue;
+  }
+
+  assert.match(result.markdown, /你好/, "final-rescue output should appear in body");
+  assert.match(result.markdown, /世界/, "final-rescue output should appear in body");
+  assert.doesNotMatch(result.markdown, /World\./, "source English must NOT remain when final-rescue accepted");
+
+  const finalRescueEvents = [...sink.events].filter((event) => event.type.startsWith("chunk.final_rescue"));
+  assert.ok(finalRescueEvents.length >= 2, "final_rescue.start + .end should both fire");
+  const endEvent = finalRescueEvents.find((e) => e.type === "chunk.final_rescue.end")!;
+  assert.equal((endEvent.meta as Record<string, unknown>).success, true);
+
+  const chunkErrorEvent = [...sink.events].find((e) => e.type === "chunk.error");
+  assert.ok(chunkErrorEvent);
+  assert.equal((chunkErrorEvent!.meta as Record<string, unknown>).finalRescueAccepted, true);
+});
+
+test("MDZH_FINAL_RESCUE_COMMAND output that fails validation still falls back to source", async () => {
+  // Final-rescue command returns a single-paragraph string but source has
+  // 2 paragraphs — paragraph_match validation should reject it and the
+  // pipeline must fall back to source content (English).
+  const source = "## Hello\n\nWorld.\n";
+
+  const executor: CodexExecutor = {
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(createEmptyAnchorCatalog());
+      }
+      if (isBundledAuditPrompt(prompt, options) || (options.outputSchema && prompt.includes('"hard_checks"'))) {
+        return createExecResult(wrapAuditForSegments(prompt, createAudit(true)));
+      }
+      throw new CodexExecutionError("draft fail");
+    }
+  };
+
+  const previousCommand = process.env.MDZH_FINAL_RESCUE_COMMAND;
+  const previousRescue = process.env.MDZH_RESCUE_MODEL;
+  // Note: emits only one paragraph — paragraph_match should fail.
+  process.env.MDZH_FINAL_RESCUE_COMMAND = "printf '只有一段中文内容，缺少标题段。'";
+  process.env.MDZH_RESCUE_MODEL = "off";
+  const sink = createMemoryTelemetrySink();
+  let result;
+  try {
+    result = await translateMarkdownArticle(source, {
+      executor,
+      formatter: async (markdown) => markdown,
+      softGate: true,
+      telemetry: sink
+    });
+  } finally {
+    if (previousCommand === undefined) delete process.env.MDZH_FINAL_RESCUE_COMMAND;
+    else process.env.MDZH_FINAL_RESCUE_COMMAND = previousCommand;
+    if (previousRescue === undefined) delete process.env.MDZH_RESCUE_MODEL;
+    else process.env.MDZH_RESCUE_MODEL = previousRescue;
+  }
+
+  // Rejected output → source fallback in effect → English remains.
+  assert.match(result.markdown, /Hello/);
+  assert.match(result.markdown, /World/);
+  const endEvent = [...sink.events].find((e) => e.type === "chunk.final_rescue.end")!;
+  assert.ok(endEvent);
+  assert.equal((endEvent.meta as Record<string, unknown>).success, false);
+  const chunkErrorEvent = [...sink.events].find((e) => e.type === "chunk.error");
+  assert.equal((chunkErrorEvent!.meta as Record<string, unknown>).finalRescueAccepted, false);
+});
+
+test("MDZH_FINAL_RESCUE_COMMAND not set: pipeline still source-fallbacks (no behaviour change vs before)", async () => {
+  const source = "## Hello\n\nWorld.\n";
+
+  const executor: CodexExecutor = {
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(createEmptyAnchorCatalog());
+      }
+      if (isBundledAuditPrompt(prompt, options) || (options.outputSchema && prompt.includes('"hard_checks"'))) {
+        return createExecResult(wrapAuditForSegments(prompt, createAudit(true)));
+      }
+      throw new CodexExecutionError("draft fail");
+    }
+  };
+
+  const previousCommand = process.env.MDZH_FINAL_RESCUE_COMMAND;
+  const previousRescue = process.env.MDZH_RESCUE_MODEL;
+  delete process.env.MDZH_FINAL_RESCUE_COMMAND;
+  process.env.MDZH_RESCUE_MODEL = "off";
+  const sink = createMemoryTelemetrySink();
+  let result;
+  try {
+    result = await translateMarkdownArticle(source, {
+      executor,
+      formatter: async (markdown) => markdown,
+      softGate: true,
+      telemetry: sink
+    });
+  } finally {
+    if (previousCommand !== undefined) process.env.MDZH_FINAL_RESCUE_COMMAND = previousCommand;
+    if (previousRescue === undefined) delete process.env.MDZH_RESCUE_MODEL;
+    else process.env.MDZH_RESCUE_MODEL = previousRescue;
+  }
+
+  // No final_rescue events at all when env unset.
+  const finalRescueEvents = [...sink.events].filter((event) => event.type.startsWith("chunk.final_rescue"));
+  assert.equal(finalRescueEvents.length, 0);
+  // Source preserved (English).
+  assert.match(result.markdown, /World/);
+});
+
 test("default behavior: repair defaults to gpt-5.5 when MDZH_REPAIR_MODEL is unset", async () => {
   // Trigger one repair cycle (audit fails on first pass, second audit passes)
   // and verify the repair stage call landed on gpt-5.5, not the mini default.


### PR DESCRIPTION
## 背景

Loonshots 长文里有 7 个稳定 fallback chunks（14/30/54/69/72/91/109）—— 它们是当前 codex 内置模型（gpt-5.4-mini / gpt-5.5）在叙事密集长 chunk 上的能力天花板，repair / rescue 都救不回。我们刚做了一轮手工修复，工作流是：

\`mdzh-translate run\` → 看到 7 个 fallback → 手动 Edit output.md 替换 7 段英文为中文 → 整本完工

要让这一步也在流水线内自动完成，需要一个机制把"更强的外部模型 / 人工 / 任意工具"接到 pipeline 末尾。

## 改动

加一个 opt-in 外部 hook，挂在 chunk-level rescue 失败之后、source-fallback 之前：

- \`MDZH_FINAL_RESCUE_COMMAND=<shell command>\`：通过 \`/bin/sh -c\` 启动，protectedSource 写到 stdin，stdout 是译文
- 输出经 \`validateFinalRescueOutput\` 校验（paragraph count / placeholder count / CJK char ratio）；通过 → 替换 chunk body；失败 → 沿用旧的 source-fallback
- \`MDZH_FINAL_RESCUE_TIMEOUT_MS\`：默认 600s

**关键设计**：

- pipeline 不绑定具体模型——shell 命令是任何用户决定接的工具
- 默认不开（env 未设置 → 跳过这一层，行为不变）
- 失败照旧 source-fallback，**完全向后兼容**
- 完全独立于 codex CLI——通过 spawn 调外部进程
- 加 \`chunk.final_rescue.start\` / \`chunk.final_rescue.end\` telemetry 事件 + \`chunk.error.meta.finalRescueAccepted\` 字段，可观测

## 验证

- 3 个新单测：
  - \`MDZH_FINAL_RESCUE_COMMAND replaces source-fallback when its output validates\` —— 命令产生合法译文 → 替换 source
  - \`MDZH_FINAL_RESCUE_COMMAND output that fails validation still falls back to source\` —— 命令产生段落数不匹配的输出 → 拒绝、source-fallback
  - \`MDZH_FINAL_RESCUE_COMMAND not set\` —— env 未设置 → 行为不变
- \`npm run verify\` 318/318 全绿

## 未来用法

loonshots 7 个硬骨头**自动修复**（不再需要手工 Edit）：

\`\`\`bash
# 用户写一个 claude-translate.sh：从 stdin 读 source，调 Claude API 翻译，stdout 输出
export MDZH_FINAL_RESCUE_COMMAND="claude-translate.sh"
node dist/src/cli.js --input loonshots.md --output loonshots.zh.md
\`\`\`

或者人工 in-the-loop：

\`\`\`bash
# pause-and-translate.sh: 把 source 发到 Slack，等译者回填
export MDZH_FINAL_RESCUE_COMMAND="pause-and-translate.sh"
\`\`\`

## 关联

- 上游：PR #108 sparse-checkpoint-resume（让 retry 仅作用于 fallback chunks）+ PR #109 loonshots case study fixture
- 一起提供"事后修复"的完整自动化路径

🤖 Generated with [Claude Code](https://claude.com/claude-code)