### PR TITLE
feat: 默认 final-rescue 一档（codex+gpt-5.5 单次直翻，宽松校验）(#115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,27 @@ md-zh-translate --input article.md --output article.zh.md
 
 ---
 
+## 翻译失败如何兜底
+
+每个分块（chunk）按以下顺序逐档下沉，前一档失败才进下一档；只要任一档产出合格中文就停在那里。
+
+| 档位 | 模型 / 入口 | 校验强度 | 默认 |
+|---|---|---|---|
+| 1. draft | `gpt-5.4-mini` | 完整 audit + 必修项门控 | 开 |
+| 2. repair × 2 | 同 draft 模型 | 同上 | 开 |
+| 3. 内置 rescue（升模型重译） | `gpt-5.5`，整段 draft+audit+repair 全套 | 完整 audit + 必修项门控 | 开 |
+| 4. 默认 final-rescue（**新**） | `gpt-5.5`，**单次直翻、无 audit** | **宽松**：段落数 = 占位符数 = 至少 1 个中文 | 开 |
+| 5. 外部 hook | `MDZH_FINAL_RESCUE_COMMAND` 指定的任意命令 | 同第 4 档 | opt-in |
+| 6. soft-gate fallback | — | — | 开（最终兜底，保留英文段） |
+
+第 4 档为本地、零配置自动启用：用同一个 `gpt-5.5`，去掉 audit / repair 这些反复挑刺的环节，只对结构（段落数、占位符、含中文）做最小校验。它是给"`gpt-5.5` 其实能翻，但 audit 老在卡"的情况设计的最后一道自动救援，避免直接落到第 6 档保留英文段。
+
+- 关掉第 4 档：`MDZH_DEFAULT_FINAL_RESCUE=off`
+- 完整契约和自定义示例：[`docs/05-advanced.md`](docs/05-advanced.md)
+- 全部相关环境变量：[`docs/03-configuration.md`](docs/03-configuration.md)
+
+---
+
 ## 你接下来想做什么？
 
 不同的入口对应不同的需求：
@@ -93,6 +114,6 @@ md-zh-translate install all            # 全部默认目标
 
 ## 项目状态
 
-- 当前默认翻译模型：`gpt-5.4-mini`，repair / rescue 升 `gpt-5.5`
+- 当前默认翻译模型：`gpt-5.4-mini`，repair / rescue / 默认 final-rescue 升 `gpt-5.5`
 - 后处理走 [`@jacobbubu/md-zh-format`](https://www.npmjs.com/package/@jacobbubu/md-zh-format) 美化
 - 持续把真实长文失败收编为 fixture，按 §3.3 「接受能力边界」管理（见 [internals/resilience-plan.md](docs/internals/resilience-plan.md)）

--- a/docs/02-how-it-works.md
+++ b/docs/02-how-it-works.md
@@ -205,9 +205,23 @@ repair 默认用 **gpt-5.5**（比初始 draft 用的 gpt-5.4-mini 强）—— 
 
 如果 rescue 也失败，进入下一层。
 
-### 2.7 External rescue hook（PR #110，opt-in）
+### 2.7 默认 final-rescue（PR #115，默认开启）
 
-当 codex 内置层（draft + repair + rescue）全都救不回时，调用用户配置的外部命令：
+当内置 rescue 也失败、`MDZH_SOFT_GATE` 仍为 true 时，pipeline 自动跑一档"默认 final-rescue"：
+
+- 仍用 `gpt-5.5`，但**不走 audit / repair**：单次直翻
+- prompt 比内置 rescue 更宽松、信息更多——含章节路径、占位符说明、可选术语表（`MDZH_RESCUE_GLOSSARY_PATH`）、可选上一段译文
+- 校验只做三件事：段落数 = 原文段落数、占位符数 = 原文占位符数、至少含 1 个中文字符
+
+设计意图：内置 rescue 用 `gpt-5.5` 走完整 audit + repair 还失败的 chunk，问题往往不是模型译不出来，而是 audit 反复挑刺把候选枪毙；这一档把 audit 拿掉，用同一个模型再试一次更宽松的版本。
+
+关闭：`MDZH_DEFAULT_FINAL_RESCUE=off`。
+
+如果这一档也失败，进入下一层。
+
+### 2.8 External rescue hook（PR #110，opt-in）
+
+当 codex 内置层（draft + repair + rescue + 默认 final-rescue）全都救不回时，调用用户配置的外部命令：
 
 ```bash
 export MDZH_FINAL_RESCUE_COMMAND="claude-translate.sh"
@@ -222,7 +236,7 @@ export MDZH_FINAL_RESCUE_COMMAND="claude-translate.sh"
 
 详见 [`05-advanced.md` § external rescue hook](05-advanced.md)。
 
-### 2.8 Soft-gate fallback to source
+### 2.9 Soft-gate fallback to source
 
 最后一层兜底：上面所有层都失败，pipeline 把这一段**保留为英文 source**（带占位符还原），继续翻下一个 chunk。
 
@@ -279,12 +293,17 @@ export MDZH_FINAL_RESCUE_COMMAND="claude-translate.sh"
   │     │   │     ├─ 命中 → done
   │     │   │     └─ 仍 fail
   │     │   │           │
-  │     │   │           ├─ External rescue hook (opt-in, MDZH_FINAL_RESCUE_COMMAND)
+  │     │   │           ├─ Default final-rescue (默认开, gpt-5.5 单次直翻, 无 audit)
   │     │   │           │     │
-  │     │   │           │     ├─ 通过校验 → done
-  │     │   │           │     └─ 仍 fail → soft-gate
-  │     │   │           │
-  │     │   │           └─ Soft-gate fallback to source (保留英文段)
+  │     │   │           │     ├─ 通过宽松校验 → done
+  │     │   │           │     └─ 仍 fail
+  │     │   │           │           │
+  │     │   │           │           ├─ External rescue hook (opt-in, MDZH_FINAL_RESCUE_COMMAND)
+  │     │   │           │           │     │
+  │     │   │           │           │     ├─ 通过校验 → done
+  │     │   │           │           │     └─ 仍 fail → soft-gate
+  │     │   │           │           │
+  │     │   │           │           └─ Soft-gate fallback to source (保留英文段)
   │     │   │
   │     │   └─ 后处理：anchor 注入、错绑清理、结构骨架对齐、reprotect
   │     │

--- a/docs/03-configuration.md
+++ b/docs/03-configuration.md
@@ -43,8 +43,31 @@ export MDZH_RESCUE_MODEL=gpt-5.5     # 默认
 export MDZH_RESCUE_MODEL=off          # 禁用 rescue（直接进 soft-gate）
 ```
 
+### `MDZH_DEFAULT_FINAL_RESCUE`（PR #115）
+**作用**：开关默认的 final-rescue 一档。位于内置 rescue（第 3 档）之后、external hook（第 5 档）之前；用 `gpt-5.5` 单次直翻、不走 audit / repair，校验只看段落数 + 占位符数 + 至少含 1 个中文字符。
+**默认**：开启
+**禁用**：`off` / `none` / `false` / `0` / 空字符串
+
+```bash
+export MDZH_DEFAULT_FINAL_RESCUE=off    # 跳过新一档，行为回到 PR #110 之前
+```
+
+注意：当 `MDZH_RESCUE_MODEL=off` 时，本档同样会被跳过——两者共享同一个 rescue 模型设置。
+
+### `MDZH_DEFAULT_FINAL_RESCUE_TIMEOUT_MS`
+**作用**：默认 final-rescue 单次 codex 调用超时（毫秒）。
+**默认**：`240000`（4 分钟）
+
+### `MDZH_RESCUE_GLOSSARY_PATH`
+**作用**：默认 final-rescue 在拼 prompt 时把这个文件原样作为"术语表"嵌入。格式不限（Markdown 表格 / `en | zh` 行 / YAML 都行）。读不到时静默跳过。
+**默认**：未设置
+
+```bash
+export MDZH_RESCUE_GLOSSARY_PATH=./loonshots-glossary.md
+```
+
 ### `MDZH_FINAL_RESCUE_COMMAND`（PR #110）
-**作用**：在所有 codex 内置层都失败后、soft-gate fallback 之前，调用用户指定的 shell 命令做最后一搏。
+**作用**：默认 final-rescue 也失败之后、soft-gate fallback 之前，调用用户指定的 shell 命令做最后一搏。
 **默认**：未设置（不启用）
 **契约**：命令通过 `/bin/sh -c` 启动，protectedSource 写到 stdin，stdout 是中文译文。
 
@@ -233,6 +256,9 @@ md-zh-translate --input mybook.md --output mybook.zh.md
 | `POST_DRAFT_MODEL` | 同 `TRANSLATION_MODEL` |
 | `MDZH_REPAIR_MODEL` | `gpt-5.5` |
 | `MDZH_RESCUE_MODEL` | `gpt-5.5` |
+| `MDZH_DEFAULT_FINAL_RESCUE` | 开启 |
+| `MDZH_DEFAULT_FINAL_RESCUE_TIMEOUT_MS` | `240000` |
+| `MDZH_RESCUE_GLOSSARY_PATH` | （未设置） |
 | `MDZH_FINAL_RESCUE_COMMAND` | （未设置） |
 | `MDZH_FINAL_RESCUE_TIMEOUT_MS` | `600000` |
 | `MDZH_CHUNK_CONCURRENCY` | `3` |

--- a/docs/05-advanced.md
+++ b/docs/05-advanced.md
@@ -12,6 +12,8 @@
 
 ## 1. External rescue hook（PR #110）
 
+> **注意**：自 PR #115 起，pipeline 已经默认带一档"默认 final-rescue"——内置 rescue 失败后用 `gpt-5.5` 单次直翻、跳过 audit / repair，校验只看段落数 + 占位符 + ≥1 中文字符。零配置就生效，绝大多数原本会落 source-fallback 的 chunk 现在会被这一档救回。本节讲的 external hook 是**再下一档**——给你接 Claude / 自己的 LLM / 句子级拆分 / 人工流程的扩展点，仅在默认 final-rescue 也失败时才被调用。开关与详细配置见 [`03-configuration.md`](03-configuration.md)。
+
 ### 1.1 什么时候要用
 
 跑完一遍长文，看到 stderr 有几行：
@@ -20,7 +22,7 @@
 Chunk 30/134 (JT AND LINDY): soft-gate caught chunk failure (...); falling back to source content.
 ```
 
-意思是这一段实在翻不出来，pipeline 保留了英文段。
+意思是这一段连默认 final-rescue 都救不回来，pipeline 保留了英文段。
 
 如果你**不想**保留英文段——希望这一段也是中文——有两条路：
 
@@ -184,14 +186,17 @@ grep 'final_rescue' $MDZH_TELEMETRY_PATH | jq '{type, chunkId, success: .meta.su
 | `command exited non-zero` | hook 内部错误 | 看 hook 的 stderr |
 | `command timed out` | 超过 `MDZH_FINAL_RESCUE_TIMEOUT_MS` | 调大超时或优化 hook 性能 |
 
-### 1.5 跟内置 rescue 的区别
+### 1.5 跟其他 rescue 档的区别
 
-| 维度 | 内置 rescue | external hook |
-|---|---|---|
-| 模型 | 必须是 codex 内置（gpt-5.5） | 任意（Claude / GPT-5 / 自己拼） |
-| 输入 | pipeline 内部组装 prompt | 你完全自由（自己写 prompt） |
-| 失败兜底 | external hook → soft-gate | soft-gate |
-| 何时触发 | repair × 2 都失败 | rescue 也失败 |
+| 维度 | 内置 rescue（第 3 档） | 默认 final-rescue（第 4 档） | external hook（第 5 档） |
+|---|---|---|---|
+| 模型 | codex `gpt-5.5` | codex `gpt-5.5` | 任意（Claude / GPT-5 / 自己拼） |
+| 流程 | 整段重走 draft+audit+repair 全套 | 单次直翻，无 audit / repair | 任意（自定义脚本） |
+| 输入 | pipeline 组装 prompt | pipeline 组装 prompt（含术语表 / 占位符说明 / 上一段译文） | 你完全自由 |
+| 校验 | 完整 audit（hard + soft） | 宽松（段落数 / 占位符 / ≥1 中文） | 同左 |
+| 何时触发 | repair × 2 都失败 | 内置 rescue 也失败 | 默认 final-rescue 也失败 |
+| 失败兜底 | 默认 final-rescue → external hook → soft-gate | external hook → soft-gate | soft-gate |
+| 默认 | 开启 | 开启 | opt-in |
 
 ---
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -13,6 +13,8 @@ export type TelemetryEventType =
   | "chunk.concurrency"
   | "chunk.rescue.start"
   | "chunk.rescue.end"
+  | "chunk.default_final_rescue.start"
+  | "chunk.default_final_rescue.end"
   | "chunk.final_rescue.start"
   | "chunk.final_rescue.end"
   | "repair.cycle"

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -309,6 +309,256 @@ function readRescueModel(): string | null {
   return trimmed;
 }
 
+/**
+ * Default "final rescue" tier sits between the heavy in-pipeline rescue
+ * (full draft + audit + repair with `gpt-5.5`) and the optional external
+ * hook (`MDZH_FINAL_RESCUE_COMMAND`). It does a single codex pass with
+ * `gpt-5.5` and no audit / repair gating — looser constraints, richer
+ * prompt context, and the same lenient `validateFinalRescueOutput` checks
+ * that the external hook uses.
+ *
+ * Enabled by default. Set `MDZH_DEFAULT_FINAL_RESCUE` to one of
+ * `off` / `none` / `false` / `0` (or empty string) to disable.
+ */
+function isDefaultFinalRescueEnabled(): boolean {
+  const raw = process.env.MDZH_DEFAULT_FINAL_RESCUE;
+  if (raw === undefined) {
+    return true;
+  }
+  const trimmed = raw.trim();
+  if (trimmed === "") {
+    return false;
+  }
+  const lower = trimmed.toLowerCase();
+  if (lower === "off" || lower === "none" || lower === "false" || lower === "0") {
+    return false;
+  }
+  return true;
+}
+
+const DEFAULT_FINAL_RESCUE_TIMEOUT_MS = 240_000;
+
+function readDefaultFinalRescueTimeoutMs(): number {
+  const raw = process.env.MDZH_DEFAULT_FINAL_RESCUE_TIMEOUT_MS?.trim();
+  if (!raw) {
+    return DEFAULT_FINAL_RESCUE_TIMEOUT_MS;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return parsed;
+  }
+  return DEFAULT_FINAL_RESCUE_TIMEOUT_MS;
+}
+
+async function loadDefaultFinalRescueGlossary(): Promise<string | null> {
+  // Optional glossary file. The pipeline reads it best-effort and inlines
+  // it into the rescue prompt verbatim — users decide the format
+  // (markdown table, YAML, plain `en | zh` lines, etc.). Failure to read
+  // is non-fatal: we just omit the glossary section and continue.
+  const raw = process.env.MDZH_RESCUE_GLOSSARY_PATH?.trim();
+  if (!raw) {
+    return null;
+  }
+  try {
+    const content = await readFile(raw, "utf8");
+    const trimmed = content.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+function describeProtectedSpanForLegend(span: ProtectedSpan): string {
+  const label = span.labelText?.trim();
+  if (label) {
+    return `${span.id} → ${span.kind} (${label})`;
+  }
+  return `${span.id} → ${span.kind}`;
+}
+
+function buildDefaultFinalRescuePrompt(input: {
+  chunk: MarkdownChunk;
+  chunkPlan: MarkdownChunkPlan;
+  protectedSource: string;
+  chunkSpans: ProtectedSpan[];
+  previousChunkBody: string | null;
+  glossary: string | null;
+}): string {
+  const sections: string[] = [];
+
+  sections.push(
+    [
+      "你是一名资深中文 Markdown 译者。前序自动流水线（draft + audit + repair + 升级模型 rescue）均已失败，",
+      "当前是最后一次自动救援机会。请严格遵守以下三条硬约束：",
+      "1. 段落数（按空行分隔的块数）必须与原文严格一致；",
+      "2. 形如 `@@MDZH_*_NNNN@@` 的占位符必须原样保留，不翻译、不改写、不增删；",
+      "3. 只输出译文本身，不要写任何说明、前言、致歉或译者注。"
+    ].join("")
+  );
+
+  const headingPath = (input.chunk.headingPath ?? []).filter(
+    (part): part is string => typeof part === "string" && part.trim().length > 0
+  );
+  const breadcrumbs = headingPath.length > 0 ? headingPath.join(" > ") : "（无章节标题）";
+  sections.push(
+    `【背景】当前为第 ${input.chunk.index + 1} / ${input.chunkPlan.chunks.length} 个分块。所在章节路径：${breadcrumbs}`
+  );
+
+  if (input.glossary) {
+    sections.push(`【术语表（请尽量遵循）】\n${input.glossary}`);
+  }
+
+  if (input.chunkSpans.length > 0) {
+    const lines = input.chunkSpans.map(describeProtectedSpanForLegend);
+    sections.push(`【占位符说明（仅作译文上下文参考，占位符本身原样保留）】\n${lines.join("\n")}`);
+  }
+
+  if (input.previousChunkBody) {
+    const trimmed = input.previousChunkBody.trim();
+    const excerpt = trimmed.length > 800 ? `${trimmed.slice(0, 800)}……` : trimmed;
+    sections.push(
+      `【上一分块译文（仅供文风 / 术语一致性参考，不是要翻译的内容）】\n${excerpt}`
+    );
+  }
+
+  sections.push(`【待翻译原文】\n${input.protectedSource}`);
+
+  sections.push(
+    "请直接输出整段中文译文。再次提醒：段落数严格相等、占位符原样保留、不要写任何解释。"
+  );
+
+  return sections.join("\n\n");
+}
+
+const DEFAULT_FINAL_RESCUE_REASONING_EFFORT: ReasoningEffort = "low";
+
+async function runDefaultFinalRescue(input: {
+  chunk: MarkdownChunk;
+  chunkPlan: MarkdownChunkPlan;
+  chunkId: string;
+  state: TranslationRunState;
+  spans: ProtectedSpan[];
+  executor: CodexExecutor;
+  cwd: string;
+  options: TranslateOptions;
+  runId: string;
+  telemetry: TelemetrySink;
+  rescueModel: string;
+  originalError: string;
+}): Promise<{ body: string | null; error: string | null }> {
+  const protectedSource = input.chunk.source;
+  const chunkSpans = input.spans.filter((span) => protectedSource.includes(span.id));
+  const previousChunk =
+    input.chunk.index > 0 ? input.state.chunks[input.chunk.index - 1] ?? null : null;
+  const previousChunkBody = previousChunk?.finalBody ?? null;
+  const glossary = await loadDefaultFinalRescueGlossary();
+  const prompt = buildDefaultFinalRescuePrompt({
+    chunk: input.chunk,
+    chunkPlan: input.chunkPlan,
+    protectedSource,
+    chunkSpans,
+    previousChunkBody,
+    glossary
+  });
+  const timeoutMs = readDefaultFinalRescueTimeoutMs();
+  const startedAt = Date.now();
+  const totalChunks = input.chunkPlan.chunks.length;
+  const headingLabel = input.chunk.headingPath.join(" > ") || "untitled";
+
+  input.telemetry.emit({
+    ts: startedAt,
+    runId: input.runId,
+    type: "chunk.default_final_rescue.start",
+    chunkId: input.chunkId,
+    meta: {
+      chunkIndex: input.chunk.index + 1,
+      rescueModel: input.rescueModel,
+      timeoutMs,
+      glossaryAttached: glossary !== null,
+      previousBodyAttached: previousChunkBody !== null,
+      promptChars: prompt.length
+    }
+  });
+  report(
+    input.options,
+    "audit",
+    `Chunk ${input.chunk.index + 1}/${totalChunks} (${headingLabel}): default final-rescue starting (model ${input.rescueModel}, single-pass, no audit).`
+  );
+
+  let body: string | null = null;
+  let error: string | null = null;
+  try {
+    const result = await executeStageWithTimeout(
+      input.executor,
+      prompt,
+      {
+        cwd: input.cwd,
+        model: input.rescueModel,
+        reasoningEffort: DEFAULT_FINAL_RESCUE_REASONING_EFFORT,
+        reuseSession: false,
+        onStderr: (stderrChunk) => {
+          const trimmed = stderrChunk.trim();
+          if (trimmed) {
+            report(input.options, "audit", trimmed);
+          }
+        }
+      },
+      {
+        options: input.options,
+        stage: "audit",
+        timeoutMs,
+        heartbeatLabel: `Chunk ${input.chunk.index + 1}/${totalChunks}: default final-rescue`,
+        onHeartbeat: (message) => report(input.options, "audit", message),
+        telemetry: input.telemetry,
+        runId: input.runId,
+        chunkId: input.chunkId,
+        extra: { lane: "default-final-rescue", model: input.rescueModel }
+      }
+    );
+    const candidate = result.text.trim();
+    if (candidate.length === 0) {
+      error = "default final-rescue produced empty output";
+    } else {
+      const validation = validateFinalRescueOutput(protectedSource, candidate);
+      if (validation.ok) {
+        body = candidate;
+      } else {
+        error = validation.reason;
+      }
+    }
+  } catch (err) {
+    error = err instanceof Error ? err.message : String(err);
+  }
+
+  input.telemetry.emit({
+    ts: Date.now(),
+    runId: input.runId,
+    type: "chunk.default_final_rescue.end",
+    chunkId: input.chunkId,
+    durationMs: Date.now() - startedAt,
+    ...(error ? { error } : {}),
+    meta: {
+      rescueModel: input.rescueModel,
+      success: body !== null
+    }
+  });
+  if (body !== null) {
+    report(
+      input.options,
+      "audit",
+      `Chunk ${input.chunk.index + 1}/${totalChunks} (${headingLabel}): default final-rescue produced an accepted translation.`
+    );
+  } else if (error) {
+    report(
+      input.options,
+      "audit",
+      `Chunk ${input.chunk.index + 1}/${totalChunks} (${headingLabel}): default final-rescue rejected (${error}).`
+    );
+  }
+
+  return { body, error };
+}
+
 const DEFAULT_CHUNK_CONCURRENCY = 3;
 
 function readChunkConcurrency(): number {
@@ -3219,13 +3469,47 @@ export async function translateMarkdownArticle(source: string, options: Translat
           }
           return;
         } else {
+          // Default final-rescue tier sits between the heavy in-pipeline
+          // rescue (full draft+audit+repair on `gpt-5.5`) and the optional
+          // external hook. It runs codex once with `gpt-5.5`, no audit and
+          // no repair gating, with a richer prompt (heading path,
+          // placeholder legend, optional glossary, optional previous chunk
+          // body for style consistency). Output is checked with the same
+          // lenient `validateFinalRescueOutput` rules used for the
+          // external hook.
+          let defaultFinalRescueBody: string | null = null;
+          const defaultRescueModel = readRescueModel();
+          if (
+            isDefaultFinalRescueEnabled() &&
+            defaultRescueModel &&
+            defaultRescueModel !== draftModel &&
+            defaultRescueModel !== postDraftModel
+          ) {
+            const outcome = await runDefaultFinalRescue({
+              chunk,
+              chunkPlan,
+              chunkId,
+              state,
+              spans,
+              executor,
+              cwd,
+              options,
+              runId,
+              telemetry,
+              rescueModel: defaultRescueModel,
+              originalError: errorMessage
+            });
+            defaultFinalRescueBody = outcome.body;
+          }
+
           // Last-line tier before source fallback: optional external "final
           // rescue" hook. The user can configure
           // `MDZH_FINAL_RESCUE_COMMAND` to plug in a stronger external
           // translator (Claude Opus, GPT-5 outside codex, sentence-level
           // splitter, human-in-the-loop). If accepted, the chunk gets a
           // real Chinese body instead of degrading to English source.
-          const finalRescueCommand = readFinalRescueCommand();
+          const finalRescueCommand =
+            defaultFinalRescueBody === null ? readFinalRescueCommand() : null;
           let finalRescueBody: string | null = null;
           let finalRescueError: string | null = null;
           if (finalRescueCommand) {
@@ -3289,6 +3573,7 @@ export async function translateMarkdownArticle(source: string, options: Translat
             }
           }
 
+          const acceptedRescueBody = defaultFinalRescueBody ?? finalRescueBody;
           telemetry.emit({
             ts: Date.now(),
             runId,
@@ -3299,10 +3584,17 @@ export async function translateMarkdownArticle(source: string, options: Translat
             meta: {
               recovered: true,
               structural: false,
-              finalRescueAccepted: finalRescueBody !== null
+              defaultFinalRescueAccepted: defaultFinalRescueBody !== null,
+              finalRescueAccepted: finalRescueBody !== null,
+              acceptedTier:
+                defaultFinalRescueBody !== null
+                  ? "default-final-rescue"
+                  : finalRescueBody !== null
+                    ? "external-final-rescue"
+                    : "source-fallback"
             }
           });
-          if (finalRescueBody === null) {
+          if (acceptedRescueBody === null) {
             report(
               options,
               "audit",
@@ -3315,8 +3607,8 @@ export async function translateMarkdownArticle(source: string, options: Translat
           // chunks.
           const chunkSpans = spans.filter((span) => chunk.source.includes(span.id));
           const recoveredBody =
-            finalRescueBody !== null
-              ? restoreMarkdownSpans(finalRescueBody, chunkSpans)
+            acceptedRescueBody !== null
+              ? restoreMarkdownSpans(acceptedRescueBody, chunkSpans)
               : restoreMarkdownSpans(chunk.source, chunkSpans);
           chunkResult = {
             body: recoveredBody,

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -3229,6 +3229,8 @@ export async function translateMarkdownArticle(source: string, options: Translat
   });
   const restoredChunks: string[] = [];
   const gateAudits: GateAudit[] = [];
+  let softGateRescuedChunks = 0;
+  let softGateSourceFallbackChunks = 0;
   let repairCyclesUsed = 0;
   let styleApplied = false;
   let nextLocalSpanIndex = spanIndex.size + 1;
@@ -3595,11 +3597,14 @@ export async function translateMarkdownArticle(source: string, options: Translat
             }
           });
           if (acceptedRescueBody === null) {
+            softGateSourceFallbackChunks += 1;
             report(
               options,
               "audit",
               `Chunk ${chunk.index + 1}/${chunkPlan.chunks.length} (${chunk.headingPath.join(" > ") || "untitled"}): soft-gate caught chunk failure (${errorMessage}); falling back to source content.`
             );
+          } else {
+            softGateRescuedChunks += 1;
           }
           // Pass only spans whose placeholder ID appears in this chunk's source
           // — restoreMarkdownSpans throws if asked to restore a span absent from
@@ -3748,12 +3753,18 @@ export async function translateMarkdownArticle(source: string, options: Translat
     const markdown = reconstructMarkdown(frontmatter, formattedBody);
     await writeDebugStateIfRequested(state);
     if (options.softGate) {
-      const softGatedChunks = gateAudits.filter((audit) => !isHardPass(audit)).length;
-      if (softGatedChunks > 0) {
+      if (softGateRescuedChunks > 0) {
         report(
           options,
           "audit",
-          `⚠ Soft-gate fallback applied to ${softGatedChunks} chunk(s). Output is degraded. Re-run with --strict-gate to fail fast instead.`
+          `ℹ ${softGateRescuedChunks} chunk(s) recovered by final-rescue tier (default and/or external hook); body is Chinese, audit was bypassed.`
+        );
+      }
+      if (softGateSourceFallbackChunks > 0) {
+        report(
+          options,
+          "audit",
+          `⚠ Soft-gate fallback applied to ${softGateSourceFallbackChunks} chunk(s); their source remains as English. Re-run with --strict-gate to fail fast instead.`
         );
       }
     }

--- a/test/default-final-rescue.test.ts
+++ b/test/default-final-rescue.test.ts
@@ -1,0 +1,335 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { translateMarkdownArticle, type GateAudit } from "../src/translate.js";
+import { CodexExecutionError } from "../src/errors.js";
+import type { CodexExecOptions, CodexExecResult, CodexExecutor } from "../src/codex-exec.js";
+import { createMemoryTelemetrySink } from "../src/telemetry.js";
+
+function isDocumentAnalysisPrompt(prompt: string): boolean {
+  return prompt.includes("【文档分析输入】");
+}
+
+function isBundledAuditPrompt(prompt: string, options: CodexExecOptions): boolean {
+  return Boolean(
+    options.outputSchema &&
+      (prompt.includes("【分段审校输入】") ||
+        prompt.includes("请检查下面按 segment 编号提供的英文原文与当前译文"))
+  );
+}
+
+function createEmptyAnchorCatalog(): string {
+  return JSON.stringify({
+    anchors: [],
+    headingPlans: [],
+    emphasisPlans: [],
+    blockPlans: [],
+    aliasPlans: [],
+    entityDisambiguationPlans: [],
+    ignoredTerms: []
+  });
+}
+
+function createPassingAudit(): GateAudit {
+  return {
+    chunk_id: "chunk-1",
+    hard_checks: {
+      mention_consistency: { pass: true, problem: "" },
+      protected_span_integrity: { pass: true, problem: "" },
+      paragraph_segmentation: { pass: true, problem: "" },
+      embedded_template_integrity: { pass: true, problem: "" }
+    },
+    soft_checks: {
+      glossary_alignment: { pass: true, problem: "" },
+      register_match: { pass: true, problem: "" },
+      readability: { pass: true, problem: "" }
+    },
+    must_fix: []
+  } as unknown as GateAudit;
+}
+
+function wrapAuditForSegments(prompt: string, audit: GateAudit): string {
+  // The bundled-audit lane expects a JSON object keyed by segment id. The
+  // tests below use a single-chunk single-segment fixture, so the segment id
+  // is a deterministic `seg-1`. Match that.
+  const segmentMatch = prompt.match(/seg-\d+/g);
+  const segments = segmentMatch ? Array.from(new Set(segmentMatch)) : ["seg-1"];
+  const segmentAudits: Record<string, unknown> = {};
+  for (const segmentId of segments) {
+    segmentAudits[segmentId] = audit;
+  }
+  return JSON.stringify({ segmentAudits });
+}
+
+function createExecResult(text: string): CodexExecResult {
+  return {
+    text,
+    stderr: "",
+    jsonl: "",
+    usage: {
+      inputTokens: 0,
+      cachedInputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0
+    }
+  };
+}
+
+const RESCUE_INPUT_LABEL = "【待翻译原文】";
+
+function withCleanRescueEnv<T>(setup: Record<string, string | undefined>, body: () => Promise<T>): Promise<T> {
+  const keys = [
+    "MDZH_DEFAULT_FINAL_RESCUE",
+    "MDZH_DEFAULT_FINAL_RESCUE_TIMEOUT_MS",
+    "MDZH_RESCUE_MODEL",
+    "MDZH_FINAL_RESCUE_COMMAND",
+    "MDZH_FINAL_RESCUE_TIMEOUT_MS",
+    "MDZH_RESCUE_GLOSSARY_PATH"
+  ] as const;
+  const previous: Record<string, string | undefined> = {};
+  for (const key of keys) {
+    previous[key] = process.env[key];
+  }
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(setup, key)) {
+      const value = setup[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    } else {
+      delete process.env[key];
+    }
+  }
+  return body().finally(() => {
+    for (const key of keys) {
+      if (previous[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previous[key];
+      }
+    }
+  });
+}
+
+test("default final-rescue: triggers when internal rescue fails under soft-gate, accepts valid output", async () => {
+  const source = "## Hello\n\nWorld.\n";
+
+  const executor: CodexExecutor = {
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(createEmptyAnchorCatalog());
+      }
+      if (isBundledAuditPrompt(prompt, options) || (options.outputSchema && prompt.includes('"hard_checks"'))) {
+        return createExecResult(wrapAuditForSegments(prompt, createPassingAudit()));
+      }
+      // The default final-rescue tier is the only call site that uses the
+      // `【待翻译原文】` section header. Recognize it and produce a valid
+      // 2-paragraph Chinese translation that matches the source structure.
+      if (prompt.includes(RESCUE_INPUT_LABEL)) {
+        // Return a strict 2-paragraph response that matches source structure
+        // — this is the contract the default tier validates against. Avoid
+        // re-extracting source from the prompt, which would risk pulling in
+        // trailing instruction lines and breaking the paragraph count.
+        return createExecResult("## 你好\n\n世界。\n");
+      }
+      // Both the primary mini draft and the in-pipeline rescue draft (gpt-5.5
+      // running through audit+repair) fail.
+      throw new CodexExecutionError("draft fail");
+    }
+  };
+
+  const sink = createMemoryTelemetrySink();
+  const result = await withCleanRescueEnv({}, () =>
+    translateMarkdownArticle(source, {
+      executor,
+      formatter: async (markdown) => markdown,
+      softGate: true,
+      telemetry: sink
+    })
+  );
+
+  assert.match(result.markdown, /你好/);
+  assert.match(result.markdown, /世界/);
+  assert.doesNotMatch(result.markdown, /World\./);
+
+  const startEvent = [...sink.events].find((e) => e.type === "chunk.default_final_rescue.start");
+  assert.ok(startEvent, "expected chunk.default_final_rescue.start event");
+  assert.equal((startEvent!.meta as Record<string, unknown>).rescueModel, "gpt-5.5");
+
+  const endEvent = [...sink.events].find((e) => e.type === "chunk.default_final_rescue.end");
+  assert.ok(endEvent, "expected chunk.default_final_rescue.end event");
+  assert.equal((endEvent!.meta as Record<string, unknown>).success, true);
+
+  const chunkErrorEvent = [...sink.events].find((e) => e.type === "chunk.error");
+  assert.ok(chunkErrorEvent);
+  const chunkErrorMeta = chunkErrorEvent!.meta as Record<string, unknown>;
+  assert.equal(chunkErrorMeta.defaultFinalRescueAccepted, true);
+  assert.equal(chunkErrorMeta.acceptedTier, "default-final-rescue");
+});
+
+test("default final-rescue: MDZH_DEFAULT_FINAL_RESCUE=off skips the new tier", async () => {
+  const source = "## Hello\n\nWorld.\n";
+
+  let defaultTierInvoked = false;
+  const executor: CodexExecutor = {
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(createEmptyAnchorCatalog());
+      }
+      if (isBundledAuditPrompt(prompt, options) || (options.outputSchema && prompt.includes('"hard_checks"'))) {
+        return createExecResult(wrapAuditForSegments(prompt, createPassingAudit()));
+      }
+      if (prompt.includes(RESCUE_INPUT_LABEL)) {
+        defaultTierInvoked = true;
+        return createExecResult("不应该到达这里");
+      }
+      throw new CodexExecutionError("draft fail");
+    }
+  };
+
+  const sink = createMemoryTelemetrySink();
+  await withCleanRescueEnv({ MDZH_DEFAULT_FINAL_RESCUE: "off" }, () =>
+    translateMarkdownArticle(source, {
+      executor,
+      formatter: async (markdown) => markdown,
+      softGate: true,
+      telemetry: sink
+    })
+  );
+
+  assert.equal(defaultTierInvoked, false, "default final-rescue must not be invoked when env=off");
+  const events = [...sink.events].filter((e) => e.type.startsWith("chunk.default_final_rescue"));
+  assert.equal(events.length, 0);
+});
+
+test("default final-rescue: success skips the external hook (default tier runs first)", async () => {
+  const source = "## Hello\n\nWorld.\n";
+
+  const executor: CodexExecutor = {
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(createEmptyAnchorCatalog());
+      }
+      if (isBundledAuditPrompt(prompt, options) || (options.outputSchema && prompt.includes('"hard_checks"'))) {
+        return createExecResult(wrapAuditForSegments(prompt, createPassingAudit()));
+      }
+      if (prompt.includes(RESCUE_INPUT_LABEL)) {
+        // Return a strict 2-paragraph response that matches source structure
+        // — this is the contract the default tier validates against. Avoid
+        // re-extracting source from the prompt, which would risk pulling in
+        // trailing instruction lines and breaking the paragraph count.
+        return createExecResult("## 你好\n\n世界。\n");
+      }
+      throw new CodexExecutionError("draft fail");
+    }
+  };
+
+  const sink = createMemoryTelemetrySink();
+  // External hook would emit DIFFERENT recognizable text — its presence in
+  // the output would mean the default tier failed to pre-empt the hook.
+  const result = await withCleanRescueEnv(
+    { MDZH_FINAL_RESCUE_COMMAND: "printf '## 外部钩子\\n\\n外部钩子内容。\\n'" },
+    () =>
+      translateMarkdownArticle(source, {
+        executor,
+        formatter: async (markdown) => markdown,
+        softGate: true,
+        telemetry: sink
+      })
+  );
+
+  assert.match(result.markdown, /你好/);
+  assert.doesNotMatch(result.markdown, /外部钩子/, "external hook must not be invoked when default tier succeeded");
+
+  const externalHookEvents = [...sink.events].filter((e) => e.type.startsWith("chunk.final_rescue"));
+  assert.equal(externalHookEvents.length, 0, "external hook events must not fire when default tier accepted");
+  const defaultTierEvents = [...sink.events].filter((e) => e.type.startsWith("chunk.default_final_rescue"));
+  assert.ok(defaultTierEvents.length >= 2, "default_final_rescue.start + .end should both fire");
+});
+
+test("default final-rescue: invalid output (paragraph mismatch) falls through to external hook", async () => {
+  const source = "## Hello\n\nWorld.\n";
+
+  const executor: CodexExecutor = {
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(createEmptyAnchorCatalog());
+      }
+      if (isBundledAuditPrompt(prompt, options) || (options.outputSchema && prompt.includes('"hard_checks"'))) {
+        return createExecResult(wrapAuditForSegments(prompt, createPassingAudit()));
+      }
+      if (prompt.includes(RESCUE_INPUT_LABEL)) {
+        // Single paragraph — paragraph_match validation should reject it.
+        return createExecResult("只有一段中文。");
+      }
+      throw new CodexExecutionError("draft fail");
+    }
+  };
+
+  const sink = createMemoryTelemetrySink();
+  const result = await withCleanRescueEnv(
+    { MDZH_FINAL_RESCUE_COMMAND: "printf '## 外部钩子\\n\\n外部钩子内容。\\n'" },
+    () =>
+      translateMarkdownArticle(source, {
+        executor,
+        formatter: async (markdown) => markdown,
+        softGate: true,
+        telemetry: sink
+      })
+  );
+
+  // Default tier rejected → external hook accepted → external hook output
+  // appears in the body.
+  assert.match(result.markdown, /外部钩子/);
+
+  const defaultEnd = [...sink.events].find((e) => e.type === "chunk.default_final_rescue.end");
+  assert.ok(defaultEnd);
+  assert.equal((defaultEnd!.meta as Record<string, unknown>).success, false);
+
+  const externalEnd = [...sink.events].find((e) => e.type === "chunk.final_rescue.end");
+  assert.ok(externalEnd, "external hook should be invoked after default tier failed");
+  assert.equal((externalEnd!.meta as Record<string, unknown>).success, true);
+
+  const chunkErrorEvent = [...sink.events].find((e) => e.type === "chunk.error");
+  const chunkErrorMeta = chunkErrorEvent!.meta as Record<string, unknown>;
+  assert.equal(chunkErrorMeta.defaultFinalRescueAccepted, false);
+  assert.equal(chunkErrorMeta.finalRescueAccepted, true);
+  assert.equal(chunkErrorMeta.acceptedTier, "external-final-rescue");
+});
+
+test("default final-rescue: MDZH_RESCUE_MODEL=off disables both internal rescue and the new tier", async () => {
+  const source = "## Hello\n\nWorld.\n";
+
+  let defaultTierInvoked = false;
+  const executor: CodexExecutor = {
+    async execute(prompt: string, options: CodexExecOptions): Promise<CodexExecResult> {
+      if (isDocumentAnalysisPrompt(prompt)) {
+        return createExecResult(createEmptyAnchorCatalog());
+      }
+      if (isBundledAuditPrompt(prompt, options) || (options.outputSchema && prompt.includes('"hard_checks"'))) {
+        return createExecResult(wrapAuditForSegments(prompt, createPassingAudit()));
+      }
+      if (prompt.includes(RESCUE_INPUT_LABEL)) {
+        defaultTierInvoked = true;
+        return createExecResult("不应到达");
+      }
+      throw new CodexExecutionError("draft fail");
+    }
+  };
+
+  const sink = createMemoryTelemetrySink();
+  const result = await withCleanRescueEnv({ MDZH_RESCUE_MODEL: "off" }, () =>
+    translateMarkdownArticle(source, {
+      executor,
+      formatter: async (markdown) => markdown,
+      softGate: true,
+      telemetry: sink
+    })
+  );
+
+  assert.equal(defaultTierInvoked, false, "default tier must skip when MDZH_RESCUE_MODEL=off");
+  // Source preserved (English) because all rescue tiers are off.
+  assert.match(result.markdown, /World/);
+});


### PR DESCRIPTION
## 关联 issue
Closes #115

## Summary
- 在内置 rescue（第 3 档）与 opt-in external hook（第 5 档）之间新增一档**默认开启**的 final-rescue：仍走 codex + `gpt-5.5`，但**单次直翻、跳过 audit / repair**；prompt 比内置 rescue 更丰富（章节路径、占位符说明、可选术语表、可选上一段译文）；校验沿用 `validateFinalRescueOutput` 的三项宽松规则（段落数 / 占位符数 / ≥1 中文）。
- 新增开关 `MDZH_DEFAULT_FINAL_RESCUE`（默认开，与 `MDZH_RESCUE_MODEL` 共享 rescue 模型决策；后者设 `off` 时本档同样跳过）和 `MDZH_DEFAULT_FINAL_RESCUE_TIMEOUT_MS`（默认 240 秒）；新增可选 `MDZH_RESCUE_GLOSSARY_PATH` 把术语表文件原样塞进 prompt。
- 新增 telemetry：`chunk.default_final_rescue.start` / `.end`；`chunk.error.meta` 增加 `defaultFinalRescueAccepted`、`acceptedTier`（`default-final-rescue` / `external-final-rescue` / `source-fallback`）。

## 行为
- External hook 契约 / 触发条件 / stdin 协议**完全不动**；唯一变化是它现在只在新一档也失败时才被调用。
- 当 `MDZH_RESCUE_MODEL=off` 时，新一档与内置 rescue 一并跳过，行为与 PR #110 之前一致。

## Test plan
- [x] `npm run typecheck` 全绿
- [x] `npm test`：323/323 通过（含 5 项新增测试）
  - 内置 rescue 失败 + softGate 启用 → 默认 tier 触发，产出有效中文，`acceptedTier=default-final-rescue`
  - `MDZH_DEFAULT_FINAL_RESCUE=off` → tier 跳过，无 telemetry 事件
  - 默认 tier 成功时，external hook 不被调用
  - 默认 tier 输出段落数错配 → 校验拒绝 → 落到 external hook 接住
  - `MDZH_RESCUE_MODEL=off` → 内置 rescue 与默认 tier 都跳过
- [ ] 真实长文 smoke 验证（建议合并前在内部跑一遍 long-form smoke 看新档对原本 fallback 的 chunk 实际救援率）

## 文档
- README 新增"翻译失败如何兜底"小节，把 6 档串清楚
- `docs/02-how-it-works.md` 新增 2.7 节，流水线图同步
- `docs/03-configuration.md` 登记三个新环境变量并更新速查表
- `docs/05-advanced.md` external hook 顶部说明它现在位于新档之后；对比表加入新一档

## 非目标（后续 issue）
- 升级 external hook 契约为 JSON 信封（携带 glossary / heading path / placeholder legend）
- 引入 `<<MDZH_RESCUE_GIVE_UP>>` sentinel 主动放弃机制

🤖 Generated with [Claude Code](https://claude.com/claude-code)